### PR TITLE
Ensure mesh is convexified before adding to environment

### DIFF
--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -2,6 +2,7 @@
 #include "taskflow_generators.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tesseract_collision/bullet/convex_hull_utils.h>
 #include <tesseract_process_managers/core/process_planning_server.h>
 #include <tesseract_motion_planners/default_planner_namespaces.h>
 #include <tesseract_process_managers/task_profiles/check_input_profile.h>
@@ -65,14 +66,14 @@ static tesseract_environment::Commands createScanAdditionCommands(const std::str
                                                                   const std::string& mesh_frame,
                                                                   const std::vector<std::string>& touch_links)
 {
-  std::vector<tesseract_geometry::ConvexMesh::Ptr> geometries =
-      tesseract_geometry::createMeshFromPath<tesseract_geometry::ConvexMesh>(filename);
+  std::vector<tesseract_geometry::Mesh::Ptr> geometries =
+      tesseract_geometry::createMeshFromPath<tesseract_geometry::Mesh>(filename);
 
   tesseract_scene_graph::Link link("scan");
-  for (tesseract_geometry::ConvexMesh::Ptr geometry : geometries)
+  for (tesseract_geometry::Mesh::Ptr geometry : geometries)
   {
     tesseract_scene_graph::Collision::Ptr collision = std::make_shared<tesseract_scene_graph::Collision>();
-    collision->geometry = geometry;
+    collision->geometry = tesseract_collision::makeConvexMesh(*geometry);
     link.collision.push_back(collision);
   }
 


### PR DESCRIPTION
The scan mesh being added to the planning environment is generally not convex, but loading it directly from file as a convex mesh implies to the collision checker that all of the vertices in the mesh represent a convex hull. AFAIK collision checking still occurs as if this mesh were a convex hull, but if the mesh is not a convex hull and has many more vertices than its convex hull (which is typical), then collision checking takes much longer. For our use case, our mesh had 150k vertices, but its convex hull had only 200 vertices. Without actually creating the convex hull of the mesh, it took several minutes (with a debug build) to load the mesh into a Bullet collision object and do collision checking, whereas the time with the convex hull was on the order of seconds.