### PR TITLE
Feature/visualize colors in scanned sim mesh

### DIFF
--- a/snp_scanning/CMakeLists.txt
+++ b/snp_scanning/CMakeLists.txt
@@ -19,9 +19,10 @@ find_package(ament_cmake REQUIRED)
 find_package(industrial_reconstruction_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(visualization_msgs REQUIRED)
+find_package(PCL REQUIRED)
 
 add_executable(open3d_sim_node src/open3d_sim_node.cpp)
-target_link_libraries(open3d_sim_node Boost::filesystem)
+target_link_libraries(open3d_sim_node Boost::filesystem ${PCL_LIBRARIES})
 ament_target_dependencies(
   open3d_sim_node
   rclcpp

--- a/snp_scanning/src/open3d_sim_node.cpp
+++ b/snp_scanning/src/open3d_sim_node.cpp
@@ -7,7 +7,6 @@
 #include <pcl/point_types.h>
 #include <pcl/PolygonMesh.h>
 #include <pcl/point_cloud.h>
-#include <stdio.h>
 #include <pcl/io/vtk_lib_io.h>
 
 

--- a/snp_scanning/src/open3d_sim_node.cpp
+++ b/snp_scanning/src/open3d_sim_node.cpp
@@ -3,6 +3,11 @@
 #include <industrial_reconstruction_msgs/srv/start_reconstruction.hpp>
 #include <industrial_reconstruction_msgs/srv/stop_reconstruction.hpp>
 #include <visualization_msgs/msg/marker.hpp>
+#include <pcl/io/ply_io.h>
+#include <pcl/point_types.h>
+#include <pcl/PolygonMesh.h>
+#include <pcl/point_cloud.h>
+
 
 static const std::string MESH_FILE_PARAMETER = "mesh_file";
 static const std::string REFERENCE_FRAME_PARAMETER = "reference_frame";
@@ -17,18 +22,60 @@ public:
     using namespace std::placeholders;
 
     start_srv_ = create_service<industrial_reconstruction_msgs::srv::StartReconstruction>(
-        "start_reconstruction", std::bind(&Open3dSimServer::startCB, this, _1, _2));
+        "start_reconstruction", std::bind(&Open3dSimServer::startCB, this, std::placeholders::_1, std::placeholders::_2));
 
     stop_srv_ = create_service<industrial_reconstruction_msgs::srv::StopReconstruction>(
-        "stop_reconstruction", std::bind(&Open3dSimServer::stopCB, this, _1, _2));
+        "stop_reconstruction", std::bind(&Open3dSimServer::stopCB, this, std::placeholders::_1, std::placeholders::_2));
 
     scan_mesh_pub_ = create_publisher<visualization_msgs::msg::Marker>(MESH_TOPIC, 10);
 
     declare_parameter<std::string>(MESH_FILE_PARAMETER, "");
-    declare_parameter<std::string>(REFERENCE_FRAME_PARAMETER, "");
+    reference_frame = declare_parameter<std::string>(REFERENCE_FRAME_PARAMETER, "");
   }
 
 private:
+  std::string reference_frame;
+  visualization_msgs::msg::Marker pclMeshToRos(const pcl::PolygonMesh& pcl_mesh) {
+      visualization_msgs::msg::Marker out_msg;
+      out_msg.header.frame_id = reference_frame; // Set your desired frame_id
+      out_msg.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
+      out_msg.action = visualization_msgs::msg::Marker::ADD;
+      out_msg.id = 1;
+      out_msg.scale.x = 1.0;
+      out_msg.scale.y = 1.0;
+      out_msg.scale.z = 1.0;
+      out_msg.pose.position.x = 0.0;
+      out_msg.pose.position.y = 0.0;
+      out_msg.pose.position.z = 0.0;
+      out_msg.pose.orientation.w = 1.0;
+      out_msg.pose.orientation.x = 0.0;
+      out_msg.pose.orientation.y = 0.0;
+      out_msg.pose.orientation.z = 0.0;
+
+      // Access vertices and polygons from the pcl::PolygonMesh
+      pcl::PointCloud<pcl::PointXYZRGB> cloud;
+      pcl::fromPCLPointCloud2(pcl_mesh.cloud, cloud);
+      const std::vector<pcl::Vertices>& polygons = pcl_mesh.polygons;
+
+      for (const pcl::Vertices& polygon : polygons) {
+          for (int vertex_index : polygon.vertices) {
+              geometry_msgs::msg::Point curr_point;
+              curr_point.x = cloud.points[vertex_index].x;
+              curr_point.y = cloud.points[vertex_index].y;
+              curr_point.z = cloud.points[vertex_index].z;
+
+              std_msgs::msg::ColorRGBA curr_point_color;
+              curr_point_color.r = cloud.points[vertex_index].r / 255.0;
+              curr_point_color.g = cloud.points[vertex_index].g / 255.0;
+              curr_point_color.b = cloud.points[vertex_index].b / 255.0;
+              curr_point_color.a = 1.0;
+              out_msg.points.push_back(curr_point);
+              out_msg.colors.push_back(curr_point_color);
+          }
+      }
+
+      return out_msg;
+    }
   void startCB(const std::shared_ptr<industrial_reconstruction_msgs::srv::StartReconstruction::Request> /*request*/,
                std::shared_ptr<industrial_reconstruction_msgs::srv::StartReconstruction::Response> response)
   {
@@ -57,23 +104,34 @@ private:
 
       // Publish the mesh
       {
-        visualization_msgs::msg::Marker mesh_marker;
-        mesh_marker.header.frame_id = reference_frame;
+//        visualization_msgs::msg::Marker mesh_marker;
+//        mesh_marker.header.frame_id = reference_frame;
 
-        mesh_marker.color.r = 200;
-        mesh_marker.color.g = 200;
-        mesh_marker.color.b = 0;
-        mesh_marker.color.a = 1;
+//        mesh_marker.color.r = 200;
+//        mesh_marker.color.g = 200;
+//        mesh_marker.color.b = 0;
+//        mesh_marker.color.a = 1;
 
-        mesh_marker.scale.x = 1;
-        mesh_marker.scale.y = 1;
-        mesh_marker.scale.z = 1;
+//        mesh_marker.scale.x = 1;
+//        mesh_marker.scale.y = 1;
+//        mesh_marker.scale.z = 1;
 
-        mesh_marker.type = visualization_msgs::msg::Marker::MESH_RESOURCE;
-        mesh_marker.mesh_resource = "file://" + mesh_file;
+//        mesh_marker.type = visualization_msgs::msg::Marker::MESH_RESOURCE;
+//        mesh_marker.mesh_resource = "file://" + mesh_file;
 
-        scan_mesh_pub_->publish(mesh_marker);
+//        scan_mesh_pub_->publish(mesh_marker);
+
+
+//        mesh_marker.type = visualization_msgs::msg::Marker::MESH_RESOURCE;
+
+        // Load the PLY mesh from a file
+        pcl::PolygonMesh pcl_mesh;
+        pcl::io::loadPLYFile(MESH_FILE_PARAMETER, pcl_mesh);
+        visualization_msgs::msg::Marker out_msg = pclMeshToRos(pcl_mesh);
+        out_msg.mesh_resource = "file://" + mesh_file;
+        scan_mesh_pub_->publish(out_msg);;
       }
+
 
       response->success = true;
       RCLCPP_INFO_STREAM(get_logger(),

--- a/snp_scanning/src/open3d_sim_node.cpp
+++ b/snp_scanning/src/open3d_sim_node.cpp
@@ -7,6 +7,8 @@
 #include <pcl/point_types.h>
 #include <pcl/PolygonMesh.h>
 #include <pcl/point_cloud.h>
+#include <stdio.h>
+#include <pcl/io/vtk_lib_io.h>
 
 
 static const std::string MESH_FILE_PARAMETER = "mesh_file";
@@ -37,7 +39,7 @@ private:
   std::string reference_frame;
   visualization_msgs::msg::Marker pclMeshToRos(const pcl::PolygonMesh& pcl_mesh) {
       visualization_msgs::msg::Marker out_msg;
-      out_msg.header.frame_id = reference_frame; // Set your desired frame_id
+      out_msg.header.frame_id = reference_frame;
       out_msg.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
       out_msg.action = visualization_msgs::msg::Marker::ADD;
       out_msg.id = 1;
@@ -104,32 +106,12 @@ private:
 
       // Publish the mesh
       {
-//        visualization_msgs::msg::Marker mesh_marker;
-//        mesh_marker.header.frame_id = reference_frame;
-
-//        mesh_marker.color.r = 200;
-//        mesh_marker.color.g = 200;
-//        mesh_marker.color.b = 0;
-//        mesh_marker.color.a = 1;
-
-//        mesh_marker.scale.x = 1;
-//        mesh_marker.scale.y = 1;
-//        mesh_marker.scale.z = 1;
-
-//        mesh_marker.type = visualization_msgs::msg::Marker::MESH_RESOURCE;
-//        mesh_marker.mesh_resource = "file://" + mesh_file;
-
-//        scan_mesh_pub_->publish(mesh_marker);
-
-
-//        mesh_marker.type = visualization_msgs::msg::Marker::MESH_RESOURCE;
-
         // Load the PLY mesh from a file
         pcl::PolygonMesh pcl_mesh;
-        pcl::io::loadPLYFile(MESH_FILE_PARAMETER, pcl_mesh);
+        pcl::io::loadPLYFile(mesh_file, pcl_mesh);
         visualization_msgs::msg::Marker out_msg = pclMeshToRos(pcl_mesh);
         out_msg.mesh_resource = "file://" + mesh_file;
-        scan_mesh_pub_->publish(out_msg);;
+        scan_mesh_pub_->publish(out_msg);
       }
 
 


### PR DESCRIPTION
Created a function in open3d_sim_node.cpp that takes in a .ply file (it seems to work with a readable ascii format mesh but not with a binary encoded .ply file) and converts it to a visualization_msgs::msg::Marker that appears in Rviz with the colors of the original mesh instead of a single solid color. This works in simulation when there is no camera or robot data.  