### PR TITLE
Remove unused variable from CI

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   clang_format:
     name: Clang-Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   cmake_format:
     name: CMake-Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -55,7 +55,6 @@ jobs:
           PREFIX: ${{ github.repository }}_
           DOCKER_IMAGE: ghcr.io/tesseract-robotics/tesseract_ros2:${{ matrix.distro }}-master
           GIT_SUBMODULE_STRATEGY: normal
-          TMPDIR: ${CI_PROJECT_DIR}.tmp
           BUILDER: colcon
           ADDITIONAL_DEBS: 'libxmlrpcpp-dev'
           UNDERLAY: /root/tesseract-robotics/tesseract_ros2_target_ws/install

--- a/snp_automate_2022/launch/start.launch.xml
+++ b/snp_automate_2022/launch/start.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <arg name="sim_vision" default="True"/>
   <arg name="sim_robot" default="True"/>
-  <arg name="sim_execution" default="$(var sim_robot)" />
+  <arg name="bypass_execution" default="$(var sim_robot)" />
   <arg name="mesh_file" default="$(find-pkg-share snp_automate_2022)/meshes/part_scan.ply"/>
   <arg name="scan_trajectory_file" default="$(find-pkg-share snp_automate_2022)/config/scan_traj.yaml"/>
   <arg name="verbose" default="True"/>
@@ -20,7 +20,7 @@
     <arg name="robot_description" value="$(var robot_description)"/>
     <arg name="robot_description_semantic" value="$(var robot_description_semantic)"/>
     <arg name="rviz" value="False"/>
-    <arg name="use_gui" value="$(var sim_execution)"/>
+    <arg name="use_gui" value="$(var bypass_execution)"/>
   </include>
 
   <node pkg="rviz2" exec="rviz2" args="-d $(find-pkg-share snp_automate_2022)/config/app.rviz">
@@ -94,12 +94,12 @@
   </group>
   <group if="$(var sim_robot)">
     <node pkg="snp_motion_execution" exec="robot_enable_simulator" />
-    <group if="$(var sim_execution)">
+    <group if="$(var bypass_execution)">
       <node pkg="snp_motion_execution" exec="execution_simulator" >
         <param name="follow_joint_trajectory_action" value="$(var follow_joint_trajectory_action)"/>
       </node>
     </group>
-    <group unless="$(var sim_execution)">
+    <group unless="$(var bypass_execution)">
       <include file="$(find-pkg-share snp_motion_execution)/launch/ros2_control.launch.py">
         <arg name="robot_description_file" value="$(var robot_description_file)"/>
         <arg name="controllers_file" value="$(find-pkg-share snp_automate_2022)/config/controllers.yaml"/>

--- a/snp_blending/launch/start.launch.xml
+++ b/snp_blending/launch/start.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <arg name="sim_vision" default="True"/>
   <arg name="sim_robot" default="True"/>
-  <arg name="sim_execution" default="$(var sim_robot)" />
+  <arg name="bypass_execution" default="$(var sim_robot)" />
   <arg name="mesh_file" default="$(find-pkg-share snp_blending)/meshes/part_scan.ply"/>
   <arg name="scan_trajectory_file" default="$(find-pkg-share snp_blending)/config/scan_traj.yaml"/>
   <arg name="verbose" default="True"/>
@@ -20,7 +20,7 @@
     <arg name="robot_description" value="$(var robot_description)"/>
     <arg name="robot_description_semantic" value="$(var robot_description_semantic)"/>
     <arg name="rviz" value="False"/>
-    <arg name="use_gui" value="$(var sim_execution)"/>
+    <arg name="use_gui" value="$(var bypass_execution)"/>
   </include>
 
   <node pkg="rviz2" exec="rviz2" args="-d $(find-pkg-share snp_blending)/config/app.rviz">
@@ -96,12 +96,12 @@
   </group>
   <group if="$(var sim_robot)">
     <node pkg="snp_motion_execution" exec="robot_enable_simulator" />
-    <group if="$(var sim_execution)">
+    <group if="$(var bypass_execution)">
       <node pkg="snp_motion_execution" exec="execution_simulator" >
         <param name="follow_joint_trajectory_action" value="$(var follow_joint_trajectory_action)"/>
       </node>
     </group>
-    <group unless="$(var sim_execution)">
+    <group unless="$(var bypass_execution)">
       <include file="$(find-pkg-share snp_motion_execution)/launch/ros2_control.launch.py">
         <arg name="robot_description_file" value="$(var robot_description_file)"/>
         <arg name="controllers_file" value="$(find-pkg-share snp_blending)/config/controllers.yaml"/>

--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -4,6 +4,8 @@
   <arg name="robot_description_semantic"/>
   <arg name="verbose" default="False"/>
   <arg name="touch_links" default="[]"/>
+  <arg name="task_composer_config_file" default="$(find-pkg-share snp_motion_planning)/config/task_composer_plugins.yaml"/>
+  <arg name="task_name" default="SNPPipeline"/>
 
   <node pkg="snp_motion_planning" exec="snp_motion_planning_node" output="screen">
     <param name="robot_description" value="$(var robot_description)"/>
@@ -15,6 +17,8 @@
     <param name="max_translational_acc" value="0.1"/>
     <param name="max_rotational_acc" value="3.14159"/>
     <param name="check_joint_acc" value="false"/>
+    <param name="task_composer_config_file" value="$(var task_composer_config_file)"/>
+    <param name="task_name" value="$(var task_name)"/>
   </node>
 
 </launch>

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -15,7 +15,6 @@
 
 #include <tesseract_time_parameterization/core/instructions_trajectory.h>
 #include <tesseract_motion_planners/core/utils.h>
-#include <tesseract_motion_planners/interface_utils.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_command_language/state_waypoint.h>
 #include <tesseract_command_language/cartesian_waypoint.h>

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -51,6 +51,8 @@ static const std::string VEL_SCALE_PARAM = "velocity_scaling_factor";
 static const std::string ACC_SCALE_PARAM = "acceleration_scaling_factor";
 static const std::string LVS_PARAM = "contact_check_longest_valid_segment";
 static const std::string CONTACT_DIST_PARAM = "contact_check_distance";
+static const std::string TASK_COMPOSER_CONFIG_FILE_PARAM = "task_composer_config_file";
+static const std::string TASK_NAME_PARAM = "task_name";
 
 tesseract_common::Toolpath fromMsg(const snp_msgs::msg::ToolPaths& msg)
 {
@@ -145,6 +147,8 @@ public:
     node_->declare_parameter<double>(ACC_SCALE_PARAM, 1.0);
     node_->declare_parameter<double>(LVS_PARAM, 0.05);
     node_->declare_parameter<double>(CONTACT_DIST_PARAM, 0.0);
+    node_->declare_parameter(TASK_COMPOSER_CONFIG_FILE_PARAM);
+    node_->declare_parameter(TASK_NAME_PARAM);
 
     {
       auto urdf_string = get<std::string>(node_, "robot_description");
@@ -377,16 +381,20 @@ private:
       planner_env->applyCommands(env_cmds);
 
       // Set up task composer problem
-      std::string config_path = ament_index_cpp::get_package_share_directory("snp_motion_planning");
-      config_path += "/config/task_composer_plugins.yaml";
-      tesseract_planning::TaskComposerPluginFactory factory(YAML::LoadFile(config_path));
-      std::string task_pipeline = "SNPPipeline";
+      auto task_composer_config_file = get<std::string>(node_, TASK_COMPOSER_CONFIG_FILE_PARAM);
+      const YAML::Node task_composer_config = YAML::LoadFile(task_composer_config_file);
+      tesseract_planning::TaskComposerPluginFactory factory(task_composer_config);
+
+      auto task_name = get<std::string>(node_, TASK_NAME_PARAM);
       auto executor = factory.createTaskComposerExecutor("TaskflowExecutor");
-      tesseract_planning::TaskComposerNode::UPtr task = factory.createTaskComposerNode(task_pipeline);
+      tesseract_planning::TaskComposerNode::UPtr task = factory.createTaskComposerNode(task_name);
+
       // Save dot graph
-      std::ofstream tc_out_data;
-      tc_out_data.open(tesseract_common::getTempPath() + "ScanNPlanPipeline.dot");
-      task->dump(tc_out_data);
+      {
+        std::ofstream tc_out_data(tesseract_common::getTempPath() + task_name + ".dot");
+        task->dump(tc_out_data);
+      }
+
       const std::string input_key = task->getInputKeys().front();
       const std::string output_key = task->getOutputKeys().front();
       tesseract_planning::TaskComposerDataStorage input_data;
@@ -401,18 +409,15 @@ private:
       if (get<bool>(node_, VERBOSE_PARAM))
       {
         console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_DEBUG);
-        // Create a dump dotgraphs of each task for reference
-        std::ofstream cartesian_pipeline_out_data;
-        cartesian_pipeline_out_data.open(tesseract_common::getTempPath() + "SNPCartesianPipeline.dot");
-        factory.createTaskComposerNode("SNPCartesianPipeline")->dump(cartesian_pipeline_out_data);
 
-        std::ofstream freespace_pipeline_out_data;
-        freespace_pipeline_out_data.open(tesseract_common::getTempPath() + "SNPFreespacePipeline.dot");
-        factory.createTaskComposerNode("SNPFreespacePipeline")->dump(freespace_pipeline_out_data);
-
-        std::ofstream transition_pipeline_out_data;
-        transition_pipeline_out_data.open(tesseract_common::getTempPath() + "SNPTransitionPipeline.dot");
-        factory.createTaskComposerNode("SNPTransitionPipeline")->dump(transition_pipeline_out_data);
+        // Dump dotgraphs of each task for reference
+        const YAML::Node& task_plugins = task_composer_config["task_composer_plugins"]["tasks"]["plugins"];
+        for (auto it = task_plugins.begin(); it != task_plugins.end(); ++it)
+        {
+          auto task_plugin_name = it->first.as<std::string>();
+          std::ofstream f(tesseract_common::getTempPath() + task_plugin_name + ".dot");
+          factory.createTaskComposerNode(task_plugin_name)->dump(f);
+        }
       }
 
       // Run problem
@@ -420,10 +425,12 @@ private:
       exec_fut->wait();
 
       auto info_map = input.task_infos.getInfoMap();
-      std::ofstream tc_out_results;
-      tc_out_results.open(tesseract_common::getTempPath() + "ScanNPlanPipelineResults.dot");
-      static_cast<const tesseract_planning::TaskComposerGraph&>(*task).dump(tc_out_results, nullptr, info_map);
-      tc_out_results.close();
+
+      // Save the output dot graph
+      {
+        std::ofstream tc_out_results(tesseract_common::getTempPath() + task_name + "_results.dot");
+        static_cast<const tesseract_planning::TaskComposerGraph&>(*task).dump(tc_out_results, nullptr, info_map);
+      }
 
       // Reset the log level
       console_bridge::setLogLevel(log_level);

--- a/snp_motion_planning/src/plugins/tasks/kinematic_limits_check_profile.hpp
+++ b/snp_motion_planning/src/plugins/tasks/kinematic_limits_check_profile.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 static const std::string KINEMATIC_LIMITS_CHECK_TASK_NAME = "KinematicLimitsCheckTask";
 


### PR DESCRIPTION
The current foxy build seems to fail because the `TMPDIR` variable is set to something specific to Gitlab:

```bash
$ docker rm 41f934a41444fb994694fcd10c3134e3cf6cd2679411b33066fc0342583e838c > /dev/null 
mktemp: failed to create file via template ‘${CI_PROJECT_DIR}.tmp/tmp.XXXXXXXXXX’: No such file or directory
/home/runner/work/_actions/ros-industrial/industrial_ci/master/industrial_ci/src/util.sh: line 414: : No such file or directory
cat: '': No such file or directory
'docker rm 41f934a41444fb994694fcd10c3134e3cf6cd2679411b33066fc0342583e838c > /dev/null ' returned with 1
```

This PR removes this variable as it is not needed for Github actions CI