### PR TITLE
Various Updates

### DIFF
--- a/snp_application/include/snp_widget.h
+++ b/snp_application/include/snp_widget.h
@@ -28,14 +28,12 @@ public:
   explicit SNPWidget(rclcpp::Node::SharedPtr node, QWidget* parent = nullptr);
 
 private:
+  rclcpp::Node::SharedPtr node_;
   Ui::SNPWidget* ui_;
   bool past_calibration_;
 
   const std::string mesh_file_;
-  const std::string motion_group_;
   const std::string reference_frame_;
-  const std::string tcp_frame_;
-  const std::string camera_frame_;
   const trajectory_msgs::msg::JointTrajectory scan_traj_;
   industrial_reconstruction_msgs::srv::StartReconstruction::Request::SharedPtr start_scan_request_;
 

--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -21,13 +21,6 @@ TrajOptMotionPlannerTask: &trajopt
     inputs: [output_data]
     outputs: [output_data]
     format_result_as_input: false
-OMPLMotionPlannerTask: &ompl
-  class: OMPLMotionPlannerTaskFactory
-  config:
-    conditional: true
-    inputs: [output_data]
-    outputs: [output_data]
-    format_result_as_input: true
 DiscreteContactCheckTask: &contact_check
   class: DiscreteContactCheckTaskFactory
   config:
@@ -99,7 +92,13 @@ task_composer_plugins:
             DoneTask: *done
             AbortTask: *abort
             MinLengthTask: *min_length
-            OMPLMotionPlannerTask: *ompl
+            OMPLMotionPlannerTask:
+              class: OMPLMotionPlannerTaskFactory
+              config:
+                conditional: true
+                inputs: [output_data]
+                outputs: [output_data]
+                format_result_as_input: true
             TrajOptMotionPlannerTask: *trajopt
             DiscreteContactCheckTask: *contact_check
             IterativeSplineParameterizationTask: *isp
@@ -128,7 +127,13 @@ task_composer_plugins:
             AbortTask: *abort
             MinLengthTask: *min_length
             TrajOptMotionPlannerTask: *trajopt
-            OMPLMotionPlannerTask: *ompl
+            OMPLMotionPlannerTask:
+              class: OMPLMotionPlannerTaskFactory
+              config:
+                conditional: true
+                inputs: [output_data]
+                outputs: [output_data]
+                format_result_as_input: false
             DiscreteContactCheckTask: *contact_check
             IterativeSplineParameterizationTask: *isp
             KinematicLimitsCheckTask: *limits_check

--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -1,8 +1,60 @@
+# Anchors
+DoneTask: &done
+  class: DoneTaskFactory
+  config:
+    conditional: false
+AbortTask: &abort
+  class: AbortTaskFactory
+  config:
+    conditional: false
+MinLengthTask: &min_length
+  class: MinLengthTaskFactory
+  config:
+    conditional: true
+    inputs: [input_data]
+    outputs: [output_data]
+    format_result_as_input: false
+TrajOptMotionPlannerTask: &trajopt
+  class: TrajOptMotionPlannerTaskFactory
+  config:
+    conditional: true
+    inputs: [output_data]
+    outputs: [output_data]
+    format_result_as_input: false
+OMPLMotionPlannerTask: &ompl
+  class: OMPLMotionPlannerTaskFactory
+  config:
+    conditional: true
+    inputs: [output_data]
+    outputs: [output_data]
+    format_result_as_input: true
+DiscreteContactCheckTask: &contact_check
+  class: DiscreteContactCheckTaskFactory
+  config:
+    conditional: true
+    inputs: [output_data]
+ConstantTCPSpeedTimeParameterizationTask: &constant_tcp_speed
+  class: ConstantTCPSpeedTimeParameterizationTaskFactory
+  config:
+    conditional: true
+    inputs: [output_data]
+    outputs: [output_data]
+IterativeSplineParameterizationTask: &isp
+  class: IterativeSplineParameterizationTaskFactory
+  config:
+    conditional: true
+    inputs: [output_data]
+    outputs: [output_data]
+KinematicLimitsCheckTask: &limits_check
+  class: KinematicLimitsCheckTaskFactory
+  config:
+    conditional: true
+    inputs: [output_data]
+    outputs: [output_data]
+
+# Task composer configuration
 task_composer_plugins:
-  search_paths:
-    - /usr/local/lib
   search_libraries:
-    - tesseract_task_composer_factories
     - snp_motion_planning_tasks
   executors:
     default: TaskflowExecutor
@@ -19,59 +71,16 @@ task_composer_plugins:
           inputs: [input_data]
           outputs: [output_data]
           nodes:
-            DoneTask:
-              class: DoneTaskFactory
-              config:
-                conditional: false
-            AbortTask:
-              class: AbortTaskFactory
-              config:
-                conditional: false
-            MinLengthTask:
-              class: MinLengthTaskFactory
-              config:
-                conditional: true
-                inputs: [input_data]
-                outputs: [output_data]
-                format_result_as_input: false
-            #DescartesMotionPlannerTask:
-            #  class: DescartesFMotionPlannerTaskFactory
-            #  config:
-            #    conditional: true
-            #    inputs: [output_data]
-            #    outputs: [output_data]
-            #    format_result_as_input: false
-            TrajOptMotionPlannerTask:
-              class: TrajOptMotionPlannerTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-                format_result_as_input: false
-            DiscreteContactCheckTask:
-              class: DiscreteContactCheckTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-            ConstantTCPSpeedTimeParameterizationTask:
-              class: ConstantTCPSpeedTimeParameterizationTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-            KinematicLimitsCheckTask:
-              class: KinematicLimitsCheckTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
+            DoneTask: *done
+            AbortTask: *abort
+            MinLengthTask: *min_length
+            TrajOptMotionPlannerTask: *trajopt
+            DiscreteContactCheckTask: *contact_check
+            ConstantTCPSpeedTimeParameterizationTask: *constant_tcp_speed
+            KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
-            #  destinations: [AbortTask, DescartesMotionPlannerTask]
               destinations: [AbortTask, TrajOptMotionPlannerTask]
-            #- source: DescartesMotionPlannerTask
-            #  destinations: [AbortTask, TrajOptMotionPlannerTask]
-            #  destinations: [AbortTask, DiscreteContactCheckTask]
             - source: TrajOptMotionPlannerTask
               destinations: [AbortTask, DiscreteContactCheckTask]
             - source: DiscreteContactCheckTask
@@ -87,54 +96,16 @@ task_composer_plugins:
           inputs: [input_data]
           outputs: [output_data]
           nodes:
-            DoneTask:
-              class: DoneTaskFactory
-              config:
-                conditional: false
-            AbortTask:
-              class: AbortTaskFactory
-              config:
-                conditional: false
-            MinLengthTask:
-              class: MinLengthTaskFactory
-              config:
-                conditional: true
-                inputs: [input_data]
-                outputs: [output_data]
-            OMPLMotionPlannerTask:
-              class: OMPLMotionPlannerTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-                format_result_as_input: true
-            TrajOptMotionPlannerTask:
-              class: TrajOptMotionPlannerTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-                format_result_as_input: false
-            DiscreteContactCheckTask:
-              class: DiscreteContactCheckTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-            IterativeSplineParameterizationTask:
-              class: IterativeSplineParameterizationTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-            KinematicLimitsCheckTask:
-              class: KinematicLimitsCheckTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
+            DoneTask: *done
+            AbortTask: *abort
+            MinLengthTask: *min_length
+            OMPLMotionPlannerTask: *ompl
+            TrajOptMotionPlannerTask: *trajopt
+            DiscreteContactCheckTask: *contact_check
+            IterativeSplineParameterizationTask: *isp
+            KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
-            #  destinations: [AbortTask, TrajOptMotionPlannerTask]
               destinations: [AbortTask, OMPLMotionPlannerTask]
             - source: OMPLMotionPlannerTask
               destinations: [AbortTask, TrajOptMotionPlannerTask]
@@ -153,51 +124,14 @@ task_composer_plugins:
           inputs: [input_data]
           outputs: [output_data]
           nodes:
-            DoneTask:
-              class: DoneTaskFactory
-              config:
-                conditional: false
-            AbortTask:
-              class: AbortTaskFactory
-              config:
-                conditional: false
-            MinLengthTask:
-              class: MinLengthTaskFactory
-              config:
-                conditional: true
-                inputs: [input_data]
-                outputs: [output_data]
-            TrajOptMotionPlannerTask:
-              class: TrajOptMotionPlannerTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-                format_result_as_input: false
-            OMPLMotionPlannerTask:
-              class: OMPLMotionPlannerTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-                format_result_as_input: true
-            DiscreteContactCheckTask:
-              class: DiscreteContactCheckTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-            IterativeSplineParameterizationTask:
-              class: IterativeSplineParameterizationTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
-            KinematicLimitsCheckTask:
-              class: KinematicLimitsCheckTaskFactory
-              config:
-                conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
+            DoneTask: *done
+            AbortTask: *abort
+            MinLengthTask: *min_length
+            TrajOptMotionPlannerTask: *trajopt
+            OMPLMotionPlannerTask: *ompl
+            DiscreteContactCheckTask: *contact_check
+            IterativeSplineParameterizationTask: *isp
+            KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
               destinations: [AbortTask, TrajOptMotionPlannerTask]
@@ -218,14 +152,8 @@ task_composer_plugins:
           inputs: [input_data]
           outputs: [output_data]
           nodes:
-            DoneTask:
-              class: DoneTaskFactory
-              config:
-                conditional: false
-            AbortTask:
-              class: AbortTaskFactory
-              config:
-                conditional: false
+            DoneTask: *done
+            AbortTask: *abort
             SimpleMotionPlannerTask:
               class: SimpleMotionPlannerTaskFactory
               config:

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -66,7 +66,9 @@ tesseract_planning::OMPLDefaultPlanProfile::Ptr createOMPLProfile()
 
   // Add as many planners as available threads so mulitple OMPL plans can happen in parallel
   auto profile = std::make_shared<tesseract_planning::OMPLDefaultPlanProfile>();
-  profile->planning_time = 20.0;
+  profile->planning_time = 5.0;
+  profile->max_solutions = 1;
+
   profile->planners.clear();
   profile->planners.reserve(static_cast<std::size_t>(n));
   for (Eigen::Index i = 0; i < n; ++i)

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -97,9 +97,9 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
   // TrajOpt profiles
   auto profile = std::make_shared<tesseract_planning::TrajOptDefaultCompositeProfile>();
   profile->smooth_velocities = true;
-  profile->velocity_coeff = Eigen::VectorXd::Constant(6, 1, 10.0);
-  profile->acceleration_coeff = Eigen::VectorXd::Constant(6, 1, 25.0);
-  profile->jerk_coeff = Eigen::VectorXd::Constant(6, 1, 50.0);
+  profile->velocity_coeff = Eigen::VectorXd::Constant(1, 1, 10.0);
+  profile->acceleration_coeff = Eigen::VectorXd::Constant(1, 1, 25.0);
+  profile->jerk_coeff = Eigen::VectorXd::Constant(1, 1, 50.0);
 
   profile->contact_test_type = tesseract_collision::ContactTestType::CLOSEST;
 

--- a/snp_tpp/src/roi_selection_mesh_modifier.cpp
+++ b/snp_tpp/src/roi_selection_mesh_modifier.cpp
@@ -24,7 +24,7 @@ std::vector<pcl::PolygonMesh> ROISelectionMeshModifier::modify(const pcl::Polygo
     {
       // Lookup transform between mesh header and
       Eigen::Isometry3d transform = tf2::transformToEigen(buffer_.lookupTransform(
-          mesh.header.frame_id, boundary_[i].header.frame_id, tf2::TimePointZero, std::chrono::milliseconds(50)));
+          mesh.header.frame_id, boundary_[i].header.frame_id, tf2::TimePointZero, std::chrono::seconds(3)));
 
       Eigen::Vector3d v;
       tf2::fromMsg(boundary_[i].point, v);


### PR DESCRIPTION
Various updates per commit messages from testing on Blending M5 project:
- Updates several motion planning parameters in the application to be read dynamically to support planning with different motion groups, TCP frames
- Leverages YAML anchors to reduce the size of the task composer config file
- Updates the OMPL tasks formatting flag
  - The OMPL task in the `SNPFreespacePipeline` is used as a seed for TrajOpt, so it should be formatted as input
  - The OMPL task in the `SNPTransitionPipeline` is used as a regular planner, so it should *not* be formatted as input
- Updates the TrajOpt velocity/acceleration/jerk costs to be 1x1 vectors to support motion groups of any size, not just 6-DoF
- Updates the OMPL profile to return the first solution and reduces the total allowed planning time to a more realistic value
