### PR TITLE
Changed base directory to `/opt`

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -52,17 +52,18 @@ jobs:
           ROS_DISTRO: ${{ matrix.distro }}
           ROS_REPO: main
           BEFORE_INIT: ''
+          BASEDIR: /opt
           PREFIX: ${{ github.repository }}_
           DOCKER_IMAGE: ghcr.io/tesseract-robotics/tesseract_ros2:${{ matrix.distro }}-0.20
           GIT_SUBMODULE_STRATEGY: normal
           BUILDER: colcon
           ADDITIONAL_DEBS: 'libxmlrpcpp-dev'
-          UNDERLAY: /root/tesseract-robotics/tesseract_ros2_target_ws/install
+          UNDERLAY: ${BASEDIR}/tesseract-robotics/tesseract_ros2_target_ws/install
           UPSTREAM_WORKSPACE: dependencies_${{ matrix.distro }}.repos
           BEFORE_BUILD_UPSTREAM_WORKSPACE_EMBED: 'ici_with_unset_variables source /opt/ros/${ROS_DISTRO}/setup.bash'
           BEFORE_RUN_TARGET_TEST_EMBED: ''
           ROSDEP_SKIP_KEYS: "tesseract_rviz tesseract_plugins rviz octomap_ros libvtk"
-          AFTER_SCRIPT: 'rm -r $BASEDIR/${PREFIX}upstream_ws/build $BASEDIR/${PREFIX}target_ws/build'
+          AFTER_SCRIPT: 'rm -r ${BASEDIR}/${PREFIX}upstream_ws/build ${BASEDIR}/${PREFIX}target_ws/build'
           DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}
 
       - name: Push post-build Docker


### PR DESCRIPTION
Changes the nominal CI build directory to `/opt`, which, unlike `/root`, is accessible to non-root users. This is valuable for using CI-built docker images in deployment where the docker containers are run with non-root users to support graphics