### PR TITLE
Created node for dynamic scan trajectories

### DIFF
--- a/snp_automate_2022/launch/start.launch.xml
+++ b/snp_automate_2022/launch/start.launch.xml
@@ -3,6 +3,7 @@
   <arg name="sim_vision" default="True"/>
   <arg name="sim_robot" default="True"/>
   <arg name="bypass_execution" default="$(var sim_robot)" />
+  <arg name="scan_from_file" default="False"/>
   <arg name="mesh_file" default="$(find-pkg-share snp_automate_2022)/meshes/part_scan.ply"/>
   <arg name="scan_trajectory_file" default="$(find-pkg-share snp_automate_2022)/config/scan_traj.yaml"/>
   <arg name="verbose" default="True"/>
@@ -46,7 +47,7 @@
 
   <!-- Launch Calibration Node and Mutable Transform Publisher Node  -->
   <!--<include file="$(find-pkg-share r2_apps)/launch/hand_eye_launch.py"/>-->
-
+$(var follow_joint_trajectory_action)
   <!-- Launch Open3d Interface Node -->
   <group unless="$(var sim_vision)">
     <node pkg="industrial_reconstruction" exec="industrial_reconstruction">
@@ -78,6 +79,28 @@
     <param name="config_file" value="$(find-pkg-share snp_automate_2022)/config/tpp.yaml"/>
   </node>
 
+  <!-- Launch Scanning Node -->
+  <group if="$(var scan_from_file)">
+    <node pkg="snp_scanning" exec="scan_motion_plan_from_file_node">
+      <param name="scan_trajectory_file" value="$(var scan_trajectory_file)"/>
+    </node>
+  </group>
+
+  <group unless="$(var scan_from_file)">
+    <node pkg="snp_scanning" exec="scan_trajectory_node" output="screen">
+      <param name="target_frame" value="scan_frame"/>
+      <param name="base_frame" value="base_link"/>
+      <param name="plane_length" value="0.5"/>
+      <param name="plane_width" value="0.3"/>
+      <param name="x_spacing" value="0.1"/>
+      <param name="y_spacing" value="0.1"/>
+      <param name="height_offset" value="0.5"/>
+      <param name="motion_group" value="manipulator"/>
+      <param name="reference_frame" value="camera_color_optical_frame"/>
+      <param name="tcp_frame" value="sand_tcp"/>
+    </node>
+  </group>
+
   <!-- Launch Motion Planning Node -->
   <include file="$(find-pkg-share snp_motion_planning)/launch/planning_server.launch.xml">
     <arg name="robot_description" value="$(var robot_description)"/>
@@ -89,10 +112,6 @@
   <!-- Launch Motion Execution Node -->
   <node pkg="snp_motion_execution" exec="motion_execution_server">
     <param name="follow_joint_trajectory_action" value="$(var follow_joint_trajectory_action)"/>
-  </node>
-
-  <node pkg="snp_scanning" exec="scan_motion_plan_from_file_node">
-    <param name="scan_trajectory_file" value="$(var scan_trajectory_file)"/>
   </node>
 
   <group unless="$(var sim_robot)">

--- a/snp_automate_2022/urdf/workcell.xacro
+++ b/snp_automate_2022/urdf/workcell.xacro
@@ -166,6 +166,14 @@
             rpy="${camera_cal['target_mount_to_target_rpy']['x']} ${camera_cal['target_mount_to_target_rpy']['y']} ${camera_cal['target_mount_to_target_rpy']['z']}" />
   </joint>
 
+  <link name="scan_frame"/>
+  <joint name="camera_to_scan_frame" type="fixed">
+    <parent link="cal_target_frame"/>
+    <child link="scan_frame"/>
+    <origin xyz="0.0 0.25 0.0" rpy="0 0 0"/>
+  </joint>
+
+
   <!-- Add TCP -->
   <link name="sand_tcp"/>
   <joint name="sand_tcp_joint" type="fixed">

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -415,11 +415,12 @@ private:
       // Set up composite instruction and environment
       tesseract_planning::CompositeInstruction program = createProgram(manip_info, fromMsg(req->tool_paths));
 
-      // Add the scan as a collision object to the environment
-      {
-        // Remove any previously added collision object
-        removeScanLink();
+      // Remove any previously added collision object
+      removeScanLink();
 
+      // Add the scan as a collision object to the environment
+      if(!req->mesh_filename.empty())
+      {
         auto collision_object_type = get<std::string>(node_, COLLISION_OBJECT_TYPE_PARAM);
         std::vector<tesseract_geometry::Geometry::Ptr> collision_objects;
         if (collision_object_type == "convex_mesh")

--- a/snp_scanning/CMakeLists.txt
+++ b/snp_scanning/CMakeLists.txt
@@ -5,12 +5,36 @@ find_package(ros_industrial_cmake_boilerplate REQUIRED)
 extract_package_metadata(pkg)
 project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX)
 
+find_package(Eigen3 REQUIRED)
+find_package(noether_tpp REQUIRED)
+
+find_package(noether_filtering REQUIRED)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 # find dependencies
-set(ROS2_DEPS industrial_reconstruction_msgs visualization_msgs rclpy)
+set(ROS2_DEPS industrial_reconstruction_msgs visualization_msgs rclpy rclcpp snp_msgs tf2_ros)
 foreach(dep ${ROS2_DEPS})
   find_package(${dep} REQUIRED)
 endforeach()
 find_package(ament_cmake REQUIRED)
+
+add_executable(scan_trajectory_node src/scan_trajectory_node.cpp)
+target_link_libraries(scan_trajectory_node noether::noether_tpp Eigen3::Eigen)
+ament_target_dependencies(scan_trajectory_node rclcpp snp_msgs tf2_ros)
+target_include_directories(scan_trajectory_node PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+
+install(TARGETS scan_trajectory_node DESTINATION lib/${PROJECT_NAME})
+
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/snp_scanning/src/scan_trajectory_node.cpp
+++ b/snp_scanning/src/scan_trajectory_node.cpp
@@ -1,0 +1,141 @@
+#include <rclcpp/rclcpp.hpp>
+#include <snp_msgs/srv/generate_scan_motion_plan.hpp>
+#include <snp_msgs/srv/generate_motion_plan.hpp>
+#include <snp_msgs/msg/tool_paths.h>
+#include <noether_tpp/tool_path_planners/flat_plane_toolpath_planner.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <Eigen/Geometry>
+
+static const std::string MESH_FILE_PARAMETER = "mesh_file";
+static const std::string TARGET_FRAME_PARAMETER = "target_frame";
+static const std::string BASE_FRAME_PARAMETER = "base_frame";
+static const std::string PLANE_LENGTH_PARAMETER = "plane_length";
+static const std::string PLANE_WIDTH_PARAMETER = "plane_width";
+static const std::string X_SPACING_PARAMETER = "x_spacing";
+static const std::string Y_SPACING_PARAMETER = "y_spacing";
+static const std::string MOTION_GROUP_PARAMETER = "motion_group";
+static const std::string TCP_FRAME_PARAMETER = "tcp_frame";
+static const std::string REFERENCE_FRAME_PARAMETER = "reference_frame";
+static const std::string HEIGHT_OFFSET_PARAMETER = "height_offset";
+
+
+class ScanTrajServer : public rclcpp::Node
+{
+public:
+  explicit ScanTrajServer(const std::string& name, const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
+    : Node(name, options), cb_group_(create_callback_group(rclcpp::CallbackGroupType::Reentrant))
+  {
+    using namespace std::placeholders;
+
+    service_ =
+            create_service<snp_msgs::srv::GenerateScanMotionPlan>("generate_scan_motion_plan",
+                                                                  std::bind(&ScanTrajServer::generateScanTrajCallback, this, std::placeholders::_1, std::placeholders::_2),
+                                                                  rmw_qos_profile_services_default,
+                                                                  cb_group_);
+    gen_scan_traj_cli_ = create_client<snp_msgs::srv::GenerateMotionPlan>("create_motion_plan");
+
+    declare_parameter<std::string>(TARGET_FRAME_PARAMETER, "");
+    declare_parameter<std::string>(BASE_FRAME_PARAMETER, "");
+    declare_parameter<double>(PLANE_LENGTH_PARAMETER, 0.0);
+    declare_parameter<double>(PLANE_WIDTH_PARAMETER, 0.0);
+    declare_parameter<double>(X_SPACING_PARAMETER, 0.0);
+    declare_parameter<double>(Y_SPACING_PARAMETER, 0.0);
+    declare_parameter<double>(HEIGHT_OFFSET_PARAMETER, 0.0);
+    declare_parameter<std::string>(MOTION_GROUP_PARAMETER, "");
+    declare_parameter<std::string>(TCP_FRAME_PARAMETER, "");
+    declare_parameter<std::string>(MESH_FILE_PARAMETER, "");
+    declare_parameter<std::string>(REFERENCE_FRAME_PARAMETER, "");
+
+  }
+
+private:
+  rclcpp::Client<snp_msgs::srv::GenerateMotionPlan>::SharedPtr gen_scan_traj_cli_;
+  rclcpp::Service<snp_msgs::srv::GenerateScanMotionPlan>::SharedPtr service_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  rclcpp::CallbackGroup::SharedPtr cb_group_;
+
+  geometry_msgs::msg::PoseArray toMsg(const noether::ToolPathSegment& segment)
+  {
+    geometry_msgs::msg::PoseArray pose_array;
+    pose_array.header.frame_id = this ->get_parameter(TARGET_FRAME_PARAMETER).as_string();
+    pose_array.poses.reserve(segment.size());
+    for (auto waypoint : segment)
+    {
+      // Renormalize orientation
+      Eigen::Quaterniond q(waypoint.linear());
+      q.normalize();
+      waypoint.matrix().block<3, 3>(0, 0) = q.toRotationMatrix();
+
+      pose_array.poses.push_back(tf2::toMsg(waypoint));
+    }
+    return pose_array;
+  }
+
+  snp_msgs::msg::ToolPath toMsg(const noether::ToolPath& path)
+  {
+    snp_msgs::msg::ToolPath path_msg;
+    path_msg.segments.reserve(path.size());
+    for (const auto& segment : path)
+      path_msg.segments.push_back(toMsg(segment));
+    return path_msg;
+  }
+
+  std::vector<snp_msgs::msg::ToolPath> toMsg(const noether::ToolPaths& paths)
+  {
+    std::vector<snp_msgs::msg::ToolPath> paths_msg;
+    paths_msg.reserve(paths.size());
+    for (const auto& path : paths)
+      paths_msg.push_back(toMsg(path));
+    return paths_msg;
+  }
+
+  void generateScanTrajCallback(const std::shared_ptr<snp_msgs::srv::GenerateScanMotionPlan::Request> req,
+               std::shared_ptr<snp_msgs::srv::GenerateScanMotionPlan::Response> res)
+  {
+    double plane_length_val = this ->get_parameter(PLANE_LENGTH_PARAMETER).as_double();
+    double plane_width_val = this ->get_parameter(PLANE_WIDTH_PARAMETER).as_double();
+    double x_spacing_val = this ->get_parameter(X_SPACING_PARAMETER).as_double();
+    double y_spacing_val = this ->get_parameter(Y_SPACING_PARAMETER).as_double();
+    double height_offset_val = this ->get_parameter(HEIGHT_OFFSET_PARAMETER).as_double();
+
+    Eigen::Vector2d plane_dims(plane_length_val,plane_width_val);
+
+    Eigen::Vector2d point_spacing(x_spacing_val,y_spacing_val);
+
+    Eigen::Isometry3d offset =
+            Eigen::Translation3d(Eigen::Vector3d(0.0, 0.0, height_offset_val)) *
+            Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX()) *
+            Eigen::Translation3d(Eigen::Vector3d(plane_length_val / 2.0, -plane_width_val / 2.0, 0.0));
+
+    noether::FlatPlaneToolPathPlanner flat_plane_tpp(plane_dims, point_spacing, offset);
+    noether::ToolPaths tps = flat_plane_tpp.plan(pcl::PolygonMesh());
+
+    auto request_ = std::make_shared<snp_msgs::srv::GenerateMotionPlan::Request>();
+    request_->motion_group = this ->get_parameter(MOTION_GROUP_PARAMETER).as_string();
+    request_->tcp_frame = this ->get_parameter(TCP_FRAME_PARAMETER).as_string();;
+    request_->tool_paths = this->toMsg(tps);
+
+    auto future = gen_scan_traj_cli_->async_send_request(request_);
+    future.wait();
+
+    snp_msgs::srv::GenerateMotionPlan::Response::SharedPtr response_ = future.get();
+    res->success = response_->success;
+    res->message = response_->message;
+    res->motion_plan = response_->motion_plan;
+  }
+};
+
+int main(int argc, char** argv)
+{
+    rclcpp::init(argc, argv);
+
+    auto node = std::make_shared<ScanTrajServer>("scan_traj_service");
+    rclcpp::executors::MultiThreadedExecutor executor;
+    executor.add_node(node);
+    executor.spin();
+    rclcpp::shutdown();
+  }


### PR DESCRIPTION
Created a node that uses a noether toolpath planner to create a configurable snakelike scanning trajectory on a plane of configuarable dimensions. The spacing of the waypoints on this plane is also configurable. 

Motion plans are generated from the given toolpaths. Current implementation does not incorporate future expected changes to the GenerateMotionPlan and GenerateScanMotionPlan services.