### PR TITLE
Added Simplified Raster Planner 

### DIFF
--- a/snp_tpp/CMakeLists.txt
+++ b/snp_tpp/CMakeLists.txt
@@ -29,12 +29,13 @@ find_package(snp_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
 
 # Custom mesh modifier
-qt5_wrap_ui(${PROJECT_NAME}_ui_mocs ui/roi_selection_mesh_modifier_widget.ui)
-qt5_wrap_cpp(${PROJECT_NAME}_mocs include/${PROJECT_NAME}/roi_selection_mesh_modifier_widget.h)
+qt5_wrap_ui(${PROJECT_NAME}_ui_mocs ui/roi_selection_mesh_modifier_widget.ui ui/snp_raster_planner_widget.ui)
+qt5_wrap_cpp(${PROJECT_NAME}_mocs include/${PROJECT_NAME}/roi_selection_mesh_modifier_widget.h include/${PROJECT_NAME}/snp_raster_planner_widget.h)
 add_library(
   ${PROJECT_NAME}_mesh_modifier SHARED
   src/roi_selection_mesh_modifier.cpp
   src/roi_selection_mesh_modifier_widget.cpp
+  src/snp_raster_planner_widget.cpp
   ${${PROJECT_NAME}_ui_mocs}
   ${${PROJECT_NAME}_mocs})
 target_include_directories(

--- a/snp_tpp/CMakeLists.txt
+++ b/snp_tpp/CMakeLists.txt
@@ -30,7 +30,8 @@ find_package(tf2_eigen REQUIRED)
 
 # Custom mesh modifier
 qt5_wrap_ui(${PROJECT_NAME}_ui_mocs ui/roi_selection_mesh_modifier_widget.ui ui/snp_raster_planner_widget.ui)
-qt5_wrap_cpp(${PROJECT_NAME}_mocs include/${PROJECT_NAME}/roi_selection_mesh_modifier_widget.h include/${PROJECT_NAME}/snp_raster_planner_widget.h)
+qt5_wrap_cpp(${PROJECT_NAME}_mocs include/${PROJECT_NAME}/roi_selection_mesh_modifier_widget.h
+             include/${PROJECT_NAME}/snp_raster_planner_widget.h)
 add_library(
   ${PROJECT_NAME}_mesh_modifier SHARED
   src/roi_selection_mesh_modifier.cpp

--- a/snp_tpp/include/snp_tpp/snp_raster_planner_widget.h
+++ b/snp_tpp/include/snp_tpp/snp_raster_planner_widget.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <noether_gui/widgets.h>
+#include <noether_tpp/tool_path_planners/raster/raster_planner.h>
+// #include <noether_gui/widgets/tpp_widget.h>
+
+namespace Ui {
+class SNPRasterPlanner;
+}
+
+namespace snp_tpp
+{
+class SNPRasterPlannerWidget : public noether::ToolPathPlannerWidget
+{
+  Q_OBJECT
+public:
+  SNPRasterPlannerWidget(QWidget* parent = nullptr);
+
+  noether::ToolPathPlanner::ConstPtr create() const override final;
+
+  void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
+
+protected:
+  Ui::SNPRasterPlanner* ui_;
+};
+
+}  // namespace snp_tpp

--- a/snp_tpp/include/snp_tpp/snp_raster_planner_widget.h
+++ b/snp_tpp/include/snp_tpp/snp_raster_planner_widget.h
@@ -2,7 +2,6 @@
 
 #include <noether_gui/widgets.h>
 #include <noether_tpp/tool_path_planners/raster/raster_planner.h>
-// #include <noether_gui/widgets/tpp_widget.h>
 
 namespace Ui
 {

--- a/snp_tpp/include/snp_tpp/snp_raster_planner_widget.h
+++ b/snp_tpp/include/snp_tpp/snp_raster_planner_widget.h
@@ -4,7 +4,8 @@
 #include <noether_tpp/tool_path_planners/raster/raster_planner.h>
 // #include <noether_gui/widgets/tpp_widget.h>
 
-namespace Ui {
+namespace Ui
+{
 class SNPRasterPlanner;
 }
 

--- a/snp_tpp/src/plugins.cpp
+++ b/snp_tpp/src/plugins.cpp
@@ -2,6 +2,8 @@
 
 #include <noether_gui/plugin_interface.h>
 #include <yaml-cpp/yaml.h>
+#include <snp_tpp/snp_raster_planner_widget.h>
+#include <noether_gui/widgets/tool_path_planners/raster/raster_planner_widget.h>
 
 namespace snp_tpp
 {
@@ -19,6 +21,22 @@ struct ROISelectionMeshModifierWidgetPlugin : public noether::MeshModifierWidget
   }
 };
 
+// Raster Tool Path Planners
+struct SNPRasterPlannerWidgetPlugin : public noether::ToolPathPlannerWidgetPlugin
+{
+  QWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
+  {
+    auto widget = new SNPRasterPlannerWidget(parent);
+
+    // Attempt to configure the widget
+    if (!config.IsNull())
+      widget->configure(config);
+
+    return widget;
+  }
+};
+
 }  // namespace snp_tpp
 
 EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(snp_tpp::ROISelectionMeshModifierWidgetPlugin, ROISelectionMeshModifier)
+EXPORT_TPP_WIDGET_PLUGIN(snp_tpp::SNPRasterPlannerWidgetPlugin, SNPRasterPlanner)

--- a/snp_tpp/src/snp_raster_planner_widget.cpp
+++ b/snp_tpp/src/snp_raster_planner_widget.cpp
@@ -1,0 +1,48 @@
+#include <snp_tpp/snp_raster_planner_widget.h>
+#include "ui_snp_raster_planner_widget.h"
+
+#include <noether_gui/utils.h>
+
+#include <noether_tpp/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.h>
+#include <noether_tpp/tool_path_planners/raster/origin_generators/centroid_origin_generator.h>
+#include <noether_tpp/tool_path_planners/raster/plane_slicer_raster_planner.h>
+
+#include <yaml-cpp/yaml.h>
+
+namespace snp_tpp
+{
+SNPRasterPlannerWidget::SNPRasterPlannerWidget(QWidget* parent)
+  : noether::ToolPathPlannerWidget(parent), ui_(new Ui::SNPRasterPlanner())
+{
+    ui_->setupUi(this);
+}
+
+void SNPRasterPlannerWidget::configure(const YAML::Node& config)
+{
+  RasterPlannerWidget::configure(config);
+  search_radius_->setValue(getEntry<double>(config, "search_radius"));
+  min_segment_size_->setValue(getEntry<double>(config, "min_segment_size"));
+}
+
+void SNPRasterPlannerWidget::save(YAML::Node& config) const
+{
+  RasterPlannerWidget::save(config);
+  config["search_radius"] = search_radius_->value();
+  config["min_segment_size"] = min_segment_size_->value();
+}
+
+noether::ToolPathPlanner::ConstPtr SNPRasterPlannerWidget::create() const
+{
+  auto dir_gen = std::make_unique<noether::PrincipalAxisDirectionGenerator>(ui_->double_spin_box_rotation_offset->value());
+  auto orig_gen = std::make_unique<noether::CentroidOriginGenerator>();
+  auto planner = std::make_unique<noether::PlaneSlicerRasterPlanner>(std::move(dir_gen), std::move(orig_gen));
+  planner->setLineSpacing(ui_->double_spin_box_line_spacing->value());
+  planner->setPointSpacing(ui_->double_spin_box_point_spacing->value());
+  planner->setMinHoleSize(0.1);
+  planner->setSearchRadius(0.1);
+  planner->setMinSegmentSize(ui_->double_spin_box_min_segment_length->value());
+
+  return planner;
+}
+
+}  // namespace noether

--- a/snp_tpp/src/snp_raster_planner_widget.cpp
+++ b/snp_tpp/src/snp_raster_planner_widget.cpp
@@ -14,26 +14,29 @@ namespace snp_tpp
 SNPRasterPlannerWidget::SNPRasterPlannerWidget(QWidget* parent)
   : noether::ToolPathPlannerWidget(parent), ui_(new Ui::SNPRasterPlanner())
 {
-    ui_->setupUi(this);
+  ui_->setupUi(this);
 }
 
 void SNPRasterPlannerWidget::configure(const YAML::Node& config)
 {
-  RasterPlannerWidget::configure(config);
-  search_radius_->setValue(getEntry<double>(config, "search_radius"));
-  min_segment_size_->setValue(getEntry<double>(config, "min_segment_size"));
+  ui_->double_spin_box_rotation_offset->setValue(noether::getEntry<double>(config, "rotation_offset"));
+  ui_->double_spin_box_point_spacing->setValue(noether::getEntry<double>(config, "point_spacing"));
+  ui_->double_spin_box_line_spacing->setValue(noether::getEntry<double>(config, "line_spacing"));
+  ui_->double_spin_box_min_segment_length->setValue(noether::getEntry<double>(config, "min_segment_length"));
 }
 
 void SNPRasterPlannerWidget::save(YAML::Node& config) const
 {
-  RasterPlannerWidget::save(config);
-  config["search_radius"] = search_radius_->value();
-  config["min_segment_size"] = min_segment_size_->value();
+  config["rotation_offset"] = ui_->double_spin_box_rotation_offset->value();
+  config["point_spacing"] = ui_->double_spin_box_point_spacing->value();
+  config["line_spacing"] = ui_->double_spin_box_line_spacing->value();
+  config["min_segment_length"] = ui_->double_spin_box_min_segment_length->value();
 }
 
 noether::ToolPathPlanner::ConstPtr SNPRasterPlannerWidget::create() const
 {
-  auto dir_gen = std::make_unique<noether::PrincipalAxisDirectionGenerator>(ui_->double_spin_box_rotation_offset->value());
+  auto dir_gen =
+      std::make_unique<noether::PrincipalAxisDirectionGenerator>(ui_->double_spin_box_rotation_offset->value());
   auto orig_gen = std::make_unique<noether::CentroidOriginGenerator>();
   auto planner = std::make_unique<noether::PlaneSlicerRasterPlanner>(std::move(dir_gen), std::move(orig_gen));
   planner->setLineSpacing(ui_->double_spin_box_line_spacing->value());
@@ -45,4 +48,4 @@ noether::ToolPathPlanner::ConstPtr SNPRasterPlannerWidget::create() const
   return planner;
 }
 
-}  // namespace noether
+}  // namespace snp_tpp

--- a/snp_tpp/ui/snp_raster_planner_widget.ui
+++ b/snp_tpp/ui/snp_raster_planner_widget.ui
@@ -54,7 +54,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="label_point_spacing">
           <property name="text">
-           <string>Point Spacing</string>
+           <string>Point Spacing (m)</string>
           </property>
          </widget>
         </item>
@@ -77,7 +77,7 @@
         <item row="2" column="0">
          <widget class="QLabel" name="label_line_spacing">
           <property name="text">
-           <string>Line Spacing</string>
+           <string>Line Spacing (m)</string>
           </property>
          </widget>
         </item>
@@ -97,7 +97,7 @@
         <item row="3" column="0">
          <widget class="QLabel" name="label_minimum_segment_length">
           <property name="text">
-           <string>Min. Segment Length</string>
+           <string>Min. Segment Length (m)</string>
           </property>
          </widget>
         </item>

--- a/snp_tpp/ui/snp_raster_planner_widget.ui
+++ b/snp_tpp/ui/snp_raster_planner_widget.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SNPRasterPlanner</class>
+ <widget class="QWidget" name="SNPRasterPlanner">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>413</width>
+    <height>373</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <widget class="QGroupBox" name="group_box_raster_planner">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>SNP Raster Planner</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QFormLayout" name="form_layout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_rotation_offset">
+          <property name="text">
+           <string>Rotation Offset (deg)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QDoubleSpinBox" name="double_spin_box_rotation_offset">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="minimum">
+           <double>-180.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>180.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_point_spacing">
+          <property name="text">
+           <string>Point Spacing</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QDoubleSpinBox" name="double_spin_box_point_spacing">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.025000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_line_spacing">
+          <property name="text">
+           <string>Line Spacing</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QDoubleSpinBox" name="double_spin_box_line_spacing">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_minimum_segment_length">
+          <property name="text">
+           <string>Min. Segment Length</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QDoubleSpinBox" name="double_spin_box_min_segment_length">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0" colspan="2">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Added a simplified tool path planner that exposes frequently tweaked tool path parameters in the GUI and hard codes the rest. 
![snp_raster_planner](https://github.com/ros-industrial-consortium/scan_n_plan_workshop/assets/76972296/4f641fb1-347a-454e-9819-acda278588f6)
