### PR TITLE
Add rel and tracking frame and live to recon request plus and declare them

### DIFF
--- a/snp_application/include/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/bt/snp_bt_ros_nodes.h
@@ -23,6 +23,17 @@ static const std::string TCP_FRAME_PARAM = "tcp_frame";
 static const std::string CAMERA_FRAME_PARAM = "camera_frame";
 static const std::string MESH_FILE_PARAM = "mesh_file";
 static const std::string START_STATE_REPLACEMENT_TOLERANCE_PARAM = "start_state_replacement_tolerance";
+static const std::string IR_TSDF_VOXEL_PARAM = "tsdf.voxel_length";
+static const std::string IR_TSDF_SDF_PARAM = "tsdf.sdf_trunc";
+static const std::string IR_TSDF_MIN_X_PARAM = "tsdf.min.x";
+static const std::string IR_TSDF_MIN_Y_PARAM = "tsdf.min.y";
+static const std::string IR_TSDF_MIN_Z_PARAM = "tsdf.min.z";
+static const std::string IR_TSDF_MAX_X_PARAM = "tsdf.max.x";
+static const std::string IR_TSDF_MAX_Y_PARAM = "tsdf.max.y";
+static const std::string IR_TSDF_MAX_Z_PARAM = "tsdf.max.z";
+static const std::string IR_RGBD_DEPTH_SCALE_PARAM = "rgbd.depth_scale";
+static const std::string IR_RGBD_DEPTH_TRUNC_PARAM = "rgbd.depth_trunc";
+static const std::string IR_LIVE_PARAM = "live";
 
 template <typename T>
 T get_parameter(rclcpp::Node::SharedPtr node, const std::string& key)

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -189,16 +189,19 @@ BT::NodeStatus GenerateToolPathsServiceNode::onResponseReceived(const typename R
 
 bool StartReconstructionServiceNode::setRequest(typename Request::SharedPtr& request)
 {
-  request->tsdf_params.voxel_length = get_parameter_or<float>(node_, "tsdf.voxel_length", 0.01f);
-  request->tsdf_params.sdf_trunc = get_parameter_or<float>(node_, "tsdf.sdf_trunc", 0.03f);
-  request->tsdf_params.min_box_values.x = get_parameter_or<double>(node_, "tsdf.min.x", 0.0);
-  request->tsdf_params.min_box_values.y = get_parameter_or<double>(node_, "tsdf.min.y", 0.0);
-  request->tsdf_params.min_box_values.z = get_parameter_or<double>(node_, "tsdf.min.z", 0.0);
-  request->tsdf_params.max_box_values.x = get_parameter_or<double>(node_, "tsdf.max.x", 0.0);
-  request->tsdf_params.max_box_values.y = get_parameter_or<double>(node_, "tsdf.max.y", 0.0);
-  request->tsdf_params.max_box_values.z = get_parameter_or<double>(node_, "tsdf.max.z", 0.0);
-  request->rgbd_params.depth_scale = get_parameter_or<float>(node_, "rgbd.depth_scale", 1000.0);
-  request->rgbd_params.depth_trunc = get_parameter_or<float>(node_, "rgbd.depth_trunc", 1.1f);
+  request->tracking_frame = get_parameter<std::string>(node_, CAMERA_FRAME_PARAM);
+  request->relative_frame = get_parameter<std::string>(node_, REF_FRAME_PARAM);
+  request->tsdf_params.voxel_length = get_parameter_or<float>(node_, IR_TSDF_VOXEL_PARAM, 0.01f);
+  request->tsdf_params.sdf_trunc = get_parameter_or<float>(node_, IR_TSDF_SDF_PARAM, 0.03f);
+  request->tsdf_params.min_box_values.x = get_parameter_or<double>(node_, IR_TSDF_MIN_X_PARAM, 0.0);
+  request->tsdf_params.min_box_values.y = get_parameter_or<double>(node_, IR_TSDF_MIN_Y_PARAM, 0.0);
+  request->tsdf_params.min_box_values.z = get_parameter_or<double>(node_, IR_TSDF_MIN_Z_PARAM, 0.0);
+  request->tsdf_params.max_box_values.x = get_parameter_or<double>(node_, IR_TSDF_MAX_X_PARAM, 0.0);
+  request->tsdf_params.max_box_values.y = get_parameter_or<double>(node_, IR_TSDF_MAX_Y_PARAM, 0.0);
+  request->tsdf_params.max_box_values.z = get_parameter_or<double>(node_, IR_TSDF_MAX_Z_PARAM, 0.0);
+  request->rgbd_params.depth_scale = get_parameter_or<float>(node_, IR_RGBD_DEPTH_SCALE_PARAM, 1000.0);
+  request->rgbd_params.depth_trunc = get_parameter_or<float>(node_, IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
+  request->live = get_parameter_or<bool>(node_, IR_LIVE_PARAM, true);
 
   return true;
 }

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -111,6 +111,18 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   bt_node_->declare_parameter<int>(BT_SHORT_TIMEOUT_PARAM, 5);    // seconds
   bt_node_->declare_parameter<int>(BT_LONG_TIMEOUT_PARAM, 6000);  // seconds
 
+  bt_node_->declare_parameter<float>(IR_TSDF_VOXEL_PARAM, 0.01f);
+  bt_node_->declare_parameter<float>(IR_TSDF_SDF_PARAM, 0.03f);
+  bt_node_->declare_parameter<double>(IR_TSDF_MIN_X_PARAM, 0.0);
+  bt_node_->declare_parameter<double>(IR_TSDF_MIN_Y_PARAM, 0.0);
+  bt_node_->declare_parameter<double>(IR_TSDF_MIN_Z_PARAM, 0.0);
+  bt_node_->declare_parameter<double>(IR_TSDF_MAX_X_PARAM, 0.0);
+  bt_node_->declare_parameter<double>(IR_TSDF_MAX_Y_PARAM, 0.0);
+  bt_node_->declare_parameter<double>(IR_TSDF_MAX_Z_PARAM, 0.0);
+  bt_node_->declare_parameter<float>(IR_RGBD_DEPTH_SCALE_PARAM, 1000.0);
+  bt_node_->declare_parameter<float>(IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
+  bt_node_->declare_parameter<bool>(IR_LIVE_PARAM, true);
+
   // Set the error message key in the blackboard
   board_->set(ERROR_MESSAGE_KEY, "");
 


### PR DESCRIPTION
- The industrial reconstruction start reconstruction request wasn't getting the tracking and relative frame set. 
- There wasn't a live parameter available
- It wasn't clear to me if the other parameters were getting set because of the `get_parameter_or` method. I'm uncertain whether this tries to declare parameters or not. If not then I don't think they are being passed from the launch file