### PR TITLE
Fully support min distance to contact during planning

### DIFF
--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -19,7 +19,7 @@
   <arg name="max_translational_acc" default="0.100"/>
   <arg name="max_rotational_acc" default="3.14"/>
   <arg name="check_joint_accelerations" default="false"/>
-  <arg name="contact_check_distance" default="0.0"/>
+  <arg name="min_contact_distance" default="0.0"/>
   <arg name="contact_check_lvs_distance" default="0.05"/>
   <arg name="ompl_max_planning_time" default="5.0"/>
   <arg name="tcp_max_speed" default="0.25"/>
@@ -44,7 +44,7 @@
     <param name="max_translational_acc" value="$(var max_translational_acc)"/>
     <param name="max_rotational_acc" value="$(var max_rotational_acc)"/>
     <param name="check_joint_accelerations" value="$(var check_joint_accelerations)"/>
-    <param name="contact_check_distance" value="$(var contact_check_distance)"/>
+    <param name="min_contact_distance" value="$(var min_contact_distance)"/>
     <param name="contact_check_lvs_distance" value="$(var contact_check_lvs_distance)"/>
     <param name="ompl_max_planning_time" value="$(var ompl_max_planning_time)"/>
     <param name="tcp_max_speed" value = "$(var tcp_max_speed)"/>

--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -4,7 +4,8 @@
   <arg name="robot_description"/>
   <arg name="robot_description_semantic"/>
   <arg name="verbose" default="False"/>
-  <arg name="touch_links" default="[]"/>
+  <arg name="scan_disabled_contact_links" default="[]"/>
+  <arg name="scan_reduced_contact_links" default="[]"/>
   <!-- Scan Link -->
   <arg name="collision_object_type" default="convex_mesh" description="Collision model representation for scan mesh (convex_mesh, mesh, octree)"/>
   <arg name="octree_resolution" default="0.010"/>
@@ -29,7 +30,8 @@
     <param name="robot_description" value="$(var robot_description)"/>
     <param name="robot_description_semantic" value="$(var robot_description_semantic)"/>
     <param name="verbose" value="$(var verbose)"/>
-    <param name="touch_links" value="$(var touch_links)"/>
+    <param name="scan_disabled_contact_links" value="$(var scan_disabled_contact_links)"/>
+    <param name="scan_reduced_contact_links" value="$(var scan_reduced_contact_links)"/>
     <!-- Scan Link -->
     <param name="collision_object_type" value="$(var collision_object_type)"/>
     <param name="octree_resolution" value="$(var octree_resolution)"/>

--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -4,8 +4,8 @@
   <arg name="robot_description"/>
   <arg name="robot_description_semantic"/>
   <arg name="verbose" default="False"/>
-  <arg name="scan_disabled_contact_links" default="[]"/>
-  <arg name="scan_reduced_contact_links" default="[]"/>
+  <arg name="scan_disabled_contact_links" default="[]" description="List of links that should be allowed to collide with the scan (e.g., link to which the scan is attached) "/>
+  <arg name="scan_reduced_contact_links" default="[]" description="List of links whose minimum acceptable contact distance to the scan should be set to 0.0 (e.g., the TCP link)"/>
   <!-- Scan Link -->
   <arg name="collision_object_type" default="convex_mesh" description="Collision model representation for scan mesh (convex_mesh, mesh, octree)"/>
   <arg name="octree_resolution" default="0.010"/>

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -17,22 +17,28 @@ static const std::string MIN_LENGTH_DEFAULT_NAMESPACE = "MinLengthTask";
 static const std::string CONTACT_CHECK_DEFAULT_NAMESPACE = "DiscreteContactCheckTask";
 static const std::string ISP_DEFAULT_NAMESPACE = "IterativeSplineParameterizationTask";
 
-struct UniqueCollisionPair
+/**
+ * @brief Container for a collision pair with a specifiable minimum allowable contact distance between the link pair
+ */
+struct ExplicitCollisionPair
 {
-  explicit UniqueCollisionPair(std::string first_, std::string second_, double distance_)
+  explicit ExplicitCollisionPair(std::string first_, std::string second_, double distance_)
     : first(first_), second(second_), distance(distance_)
   {
   }
 
+  /** @brief Name of the first link */
   std::string first;
+  /** @brief Name of the second link */
   std::string second;
+  /** @brief Minimum allowable contact distance between the two links */
   double distance;
 };
 
 template <typename FloatType>
 typename tesseract_planning::DescartesDefaultPlanProfile<FloatType>::Ptr
 createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatType>(0.0),
-                           const std::vector<UniqueCollisionPair>& unique_collision_pairs = {})
+                           const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {})
 {
   auto profile = std::make_shared<tesseract_planning::DescartesDefaultPlanProfile<FloatType>>();
   profile->num_threads = static_cast<int>(std::thread::hardware_concurrency());
@@ -47,7 +53,7 @@ createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatTyp
 
   profile->vertex_collision_check_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::MODIFY;
-  for (const UniqueCollisionPair& pair : unique_collision_pairs)
+  for (const ExplicitCollisionPair& pair : unique_collision_pairs)
     profile->vertex_collision_check_config.contact_manager_config.margin_data.setPairCollisionMargin(
         pair.first, pair.second, pair.distance);
 
@@ -58,7 +64,7 @@ createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatTyp
 
   profile->edge_collision_check_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::MODIFY;
-  for (const UniqueCollisionPair& pair : unique_collision_pairs)
+  for (const ExplicitCollisionPair& pair : unique_collision_pairs)
     profile->edge_collision_check_config.contact_manager_config.margin_data.setPairCollisionMargin(
         pair.first, pair.second, pair.distance);
 
@@ -90,7 +96,7 @@ createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatTyp
 }
 
 tesseract_planning::OMPLDefaultPlanProfile::Ptr createOMPLProfile(
-    const double min_contact_distance = 0.0, const std::vector<UniqueCollisionPair>& unique_collision_pairs = {})
+    const double min_contact_distance = 0.0, const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {})
 {
   // OMPL freespace and transition profiles
   // Create the RRT parameters
@@ -117,7 +123,7 @@ tesseract_planning::OMPLDefaultPlanProfile::Ptr createOMPLProfile(
   profile->collision_check_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::MODIFY;
 
-  for (const UniqueCollisionPair& pair : unique_collision_pairs)
+  for (const ExplicitCollisionPair& pair : unique_collision_pairs)
     profile->collision_check_config.contact_manager_config.margin_data.setPairCollisionMargin(pair.first, pair.second,
                                                                                               pair.distance);
 
@@ -133,7 +139,7 @@ std::shared_ptr<tesseract_planning::TrajOptPlanProfile> createTrajOptToolZFreePl
 }
 
 std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOptProfile(
-    double min_contact_distance = 0.0, const std::vector<UniqueCollisionPair>& unique_collision_pairs = {})
+    double min_contact_distance = 0.0, const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {})
 {
   // TrajOpt profiles
   auto profile = std::make_shared<tesseract_planning::TrajOptDefaultCompositeProfile>();
@@ -152,7 +158,7 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
 
   profile->special_collision_cost =
       std::make_shared<trajopt_common::SafetyMarginData>(min_contact_distance, profile->collision_cost_config.coeff);
-  for (const UniqueCollisionPair& pair : unique_collision_pairs)
+  for (const ExplicitCollisionPair& pair : unique_collision_pairs)
     profile->special_collision_cost->setPairSafetyMarginData(pair.first, pair.second, pair.distance,
                                                              profile->collision_cost_config.coeff);
 
@@ -168,14 +174,14 @@ std::shared_ptr<tesseract_planning::SimplePlannerLVSPlanProfile> createSimplePla
 
 tesseract_planning::ContactCheckProfile::Ptr
 createContactCheckProfile(double longest_valid_segment_distance, double min_contact_distance = 0.0,
-                          const std::vector<UniqueCollisionPair>& collision_pairs = {})
+                          const std::vector<ExplicitCollisionPair>& collision_pairs = {})
 {
   auto profile =
       std::make_shared<tesseract_planning::ContactCheckProfile>(longest_valid_segment_distance, min_contact_distance);
   profile->config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
   profile->config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::MODIFY;
-  for (const UniqueCollisionPair& pair : collision_pairs)
+  for (const ExplicitCollisionPair& pair : collision_pairs)
     profile->config.contact_manager_config.margin_data.setPairCollisionMargin(pair.first, pair.second, pair.distance);
 
   return profile;

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -7,6 +7,7 @@
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_plan_profile.h>
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
 #include <tesseract_motion_planners/simple/profile/simple_planner_lvs_plan_profile.h>
+#include <tesseract_task_composer/planning/profiles/contact_check_profile.h>
 
 static const std::string TRAJOPT_DEFAULT_NAMESPACE = "TrajOptMotionPlannerTask";
 static const std::string OMPL_DEFAULT_NAMESPACE = "OMPLMotionPlannerTask";
@@ -163,4 +164,19 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
 std::shared_ptr<tesseract_planning::SimplePlannerLVSPlanProfile> createSimplePlannerProfile()
 {
   return std::make_shared<tesseract_planning::SimplePlannerLVSPlanProfile>(5 * M_PI / 180, 0.1, 5 * M_PI / 180, 1);
+}
+
+tesseract_planning::ContactCheckProfile::Ptr
+createContactCheckProfile(double longest_valid_segment_distance, double min_contact_distance = 0.0,
+                          const std::vector<UniqueCollisionPair>& collision_pairs = {})
+{
+  auto profile =
+      std::make_shared<tesseract_planning::ContactCheckProfile>(longest_valid_segment_distance, min_contact_distance);
+  profile->config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+  profile->config.contact_manager_config.margin_data_override_type =
+      tesseract_common::CollisionMarginOverrideType::MODIFY;
+  for (const UniqueCollisionPair& pair : collision_pairs)
+    profile->config.contact_manager_config.margin_data.setPairCollisionMargin(pair.first, pair.second, pair.distance);
+
+  return profile;
 }


### PR DESCRIPTION
Currently the contact check task checks if a trajectory is a specified minimum distance from contact, but none of the planners create trajectories considering this constraint. This PR adds this minimum distance to contact value to the collision margin config of the custom Descartes, OMPL, and Trajopt profiles

Builds on #87 