### PR TITLE
Added parameters for StopReconstruction service arguments

### DIFF
--- a/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
@@ -25,17 +25,23 @@ static const std::string TCP_FRAME_PARAM = "tcp_frame";
 static const std::string CAMERA_FRAME_PARAM = "camera_frame";
 static const std::string MESH_FILE_PARAM = "mesh_file";
 static const std::string START_STATE_REPLACEMENT_TOLERANCE_PARAM = "start_state_replacement_tolerance";
-static const std::string IR_TSDF_VOXEL_PARAM = "tsdf.voxel_length";
-static const std::string IR_TSDF_SDF_PARAM = "tsdf.sdf_trunc";
-static const std::string IR_TSDF_MIN_X_PARAM = "tsdf.min.x";
-static const std::string IR_TSDF_MIN_Y_PARAM = "tsdf.min.y";
-static const std::string IR_TSDF_MIN_Z_PARAM = "tsdf.min.z";
-static const std::string IR_TSDF_MAX_X_PARAM = "tsdf.max.x";
-static const std::string IR_TSDF_MAX_Y_PARAM = "tsdf.max.y";
-static const std::string IR_TSDF_MAX_Z_PARAM = "tsdf.max.z";
-static const std::string IR_RGBD_DEPTH_SCALE_PARAM = "rgbd.depth_scale";
-static const std::string IR_RGBD_DEPTH_TRUNC_PARAM = "rgbd.depth_trunc";
-static const std::string IR_LIVE_PARAM = "live";
+static const std::string IR_TSDF_VOXEL_PARAM = "ir.tsdf.voxel_length";
+static const std::string IR_TSDF_SDF_PARAM = "ir.tsdf.sdf_trunc";
+static const std::string IR_TSDF_MIN_X_PARAM = "ir.tsdf.min.x";
+static const std::string IR_TSDF_MIN_Y_PARAM = "ir.tsdf.min.y";
+static const std::string IR_TSDF_MIN_Z_PARAM = "ir.tsdf.min.z";
+static const std::string IR_TSDF_MAX_X_PARAM = "ir.tsdf.max.x";
+static const std::string IR_TSDF_MAX_Y_PARAM = "ir.tsdf.max.y";
+static const std::string IR_TSDF_MAX_Z_PARAM = "ir.tsdf.max.z";
+static const std::string IR_RGBD_DEPTH_SCALE_PARAM = "ir.rgbd.depth_scale";
+static const std::string IR_RGBD_DEPTH_TRUNC_PARAM = "ir.rgbd.depth_trunc";
+static const std::string IR_LIVE_PARAM = "ir.live";
+static const std::string IR_MIN_FACES_PARAM = "ir.min_faces";
+static const std::string IR_NORMAL_ANGLE_TOL_PARAM = "ir.normal_angle_tol";
+static const std::string IR_NORMAL_X_PARAM = "ir.normal_x";
+static const std::string IR_NORMAL_Y_PARAM = "ir.normal_y";
+static const std::string IR_NORMAL_Z_PARAM = "ir.normal_z";
+static const std::string IR_ARCHIVE_DIR_PARAM = "ir.archive_dir";
 
 template <typename T>
 T get_parameter(rclcpp::Node::SharedPtr node, const std::string& key)

--- a/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
@@ -19,12 +19,14 @@
 
 namespace snp_application
 {
+// Parameters
 static const std::string MOTION_GROUP_PARAM = "motion_group";
 static const std::string REF_FRAME_PARAM = "reference_frame";
 static const std::string TCP_FRAME_PARAM = "tcp_frame";
 static const std::string CAMERA_FRAME_PARAM = "camera_frame";
 static const std::string MESH_FILE_PARAM = "mesh_file";
 static const std::string START_STATE_REPLACEMENT_TOLERANCE_PARAM = "start_state_replacement_tolerance";
+//   Industrial Reconstruction
 static const std::string IR_TSDF_VOXEL_PARAM = "ir.tsdf.voxel_length";
 static const std::string IR_TSDF_SDF_PARAM = "ir.tsdf.sdf_trunc";
 static const std::string IR_TSDF_MIN_X_PARAM = "ir.tsdf.min.x";

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -158,12 +158,21 @@ bool StopReconstructionServiceNode::setRequest(typename Request::SharedPtr& requ
   request->mesh_filepath = get_parameter<std::string>(node_, MESH_FILE_PARAM);
   request->min_num_faces = get_parameter<int>(node_, IR_MIN_FACES_PARAM);
 
-  industrial_reconstruction_msgs::msg::NormalFilterParams norm_filt;
-  norm_filt.normal_direction.x = get_parameter_or<double>(node_, IR_NORMAL_X_PARAM, 0.0);
-  norm_filt.normal_direction.y = get_parameter_or<double>(node_, IR_NORMAL_Y_PARAM, 0.0);
-  norm_filt.normal_direction.z = get_parameter_or<double>(node_, IR_NORMAL_Z_PARAM, 1.0);
-  norm_filt.angle = get_parameter_or<double>(node_, IR_NORMAL_ANGLE_TOL_PARAM, 180.0);
-  request->normal_filters.push_back(norm_filt);
+  try
+  {
+    industrial_reconstruction_msgs::msg::NormalFilterParams norm_filt;
+    norm_filt.angle = get_parameter<double>(node_, IR_NORMAL_ANGLE_TOL_PARAM);
+    norm_filt.normal_direction.x = get_parameter<double>(node_, IR_NORMAL_X_PARAM);
+    norm_filt.normal_direction.y = get_parameter<double>(node_, IR_NORMAL_Y_PARAM);
+    norm_filt.normal_direction.z = get_parameter<double>(node_, IR_NORMAL_Z_PARAM);
+
+    // Do not add a normal filter if the angle is less than 0.0
+    if (norm_filt.angle > 0.0)
+      request->normal_filters.push_back(norm_filt);
+  }
+  catch(const std::exception&)
+  {
+  }
 
   return true;
 }

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -170,8 +170,10 @@ bool StopReconstructionServiceNode::setRequest(typename Request::SharedPtr& requ
     if (norm_filt.angle > 0.0)
       request->normal_filters.push_back(norm_filt);
   }
-  catch(const std::exception&)
+  catch (const std::exception& ex)
   {
+    config().blackboard->set(ERROR_MESSAGE_KEY, ex.what());
+    return false;
   }
 
   return true;

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -154,15 +154,15 @@ BT::NodeStatus StartReconstructionServiceNode::onResponseReceived(const typename
 
 bool StopReconstructionServiceNode::setRequest(typename Request::SharedPtr& request)
 {
-  request->archive_directory = "";
+  request->archive_directory = get_parameter_or<std::string>(node_, IR_ARCHIVE_DIR_PARAM, "");
   request->mesh_filepath = get_parameter<std::string>(node_, MESH_FILE_PARAM);
-  request->min_num_faces = 1000;
+  request->min_num_faces = get_parameter<int>(node_, IR_MIN_FACES_PARAM);
 
   industrial_reconstruction_msgs::msg::NormalFilterParams norm_filt;
-  norm_filt.normal_direction.x = 0;
-  norm_filt.normal_direction.y = 0;
-  norm_filt.normal_direction.z = 1;
-  norm_filt.angle = 85;
+  norm_filt.normal_direction.x = get_parameter_or<double>(node_, IR_NORMAL_X_PARAM, 0.0);
+  norm_filt.normal_direction.y = get_parameter_or<double>(node_, IR_NORMAL_Y_PARAM, 0.0);
+  norm_filt.normal_direction.z = get_parameter_or<double>(node_, IR_NORMAL_Z_PARAM, 1.0);
+  norm_filt.angle = get_parameter_or<double>(node_, IR_NORMAL_ANGLE_TOL_PARAM, 180.0);
   request->normal_filters.push_back(norm_filt);
 
   return true;

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -122,6 +122,12 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   bt_node_->declare_parameter<float>(IR_RGBD_DEPTH_SCALE_PARAM, 1000.0);
   bt_node_->declare_parameter<float>(IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
   bt_node_->declare_parameter<bool>(IR_LIVE_PARAM, true);
+  bt_node_->declare_parameter<int>(IR_MIN_FACES_PARAM, 0);
+  bt_node_->declare_parameter<double>(IR_NORMAL_ANGLE_TOL_PARAM, 180.0);
+  bt_node_->declare_parameter<double>(IR_NORMAL_X_PARAM, 0.0);
+  bt_node_->declare_parameter<double>(IR_NORMAL_Y_PARAM, 0.0);
+  bt_node_->declare_parameter<double>(IR_NORMAL_Z_PARAM, 1.0);
+  bt_node_->declare_parameter<std::string>(IR_ARCHIVE_DIR_PARAM, "");
 
   // Set the error message key in the blackboard
   board_->set(ERROR_MESSAGE_KEY, "");

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -123,7 +123,7 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   bt_node_->declare_parameter<float>(IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
   bt_node_->declare_parameter<bool>(IR_LIVE_PARAM, true);
   bt_node_->declare_parameter<int>(IR_MIN_FACES_PARAM, 0);
-  bt_node_->declare_parameter<double>(IR_NORMAL_ANGLE_TOL_PARAM, 180.0);
+  bt_node_->declare_parameter<double>(IR_NORMAL_ANGLE_TOL_PARAM, -1.0);
   bt_node_->declare_parameter<double>(IR_NORMAL_X_PARAM, 0.0);
   bt_node_->declare_parameter<double>(IR_NORMAL_Y_PARAM, 0.0);
   bt_node_->declare_parameter<double>(IR_NORMAL_Z_PARAM, 1.0);


### PR DESCRIPTION
Addresses #91. Also nests the parameters in the `ir.` namespace so that all `industrial_reconstruction` parameters show up together in `rqt`