### PR TITLE
Update default empty list args as a workaround for ros2 launch issue

### DIFF
--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -4,8 +4,9 @@
   <arg name="robot_description"/>
   <arg name="robot_description_semantic"/>
   <arg name="verbose" default="False"/>
-  <arg name="scan_disabled_contact_links" default="[]" description="List of links that should be allowed to collide with the scan (e.g., link to which the scan is attached) "/>
-  <arg name="scan_reduced_contact_links" default="[]" description="List of links whose minimum acceptable contact distance to the scan should be set to 0.0 (e.g., the TCP link)"/>
+  <!-- Add empty string to empty list so parameter exceptions aren't thrown. See https://github.com/ros2/rclcpp/issues/1955 -->
+  <arg name="scan_disabled_contact_links" default="['']" description="List of links that should be allowed to collide with the scan (e.g., link to which the scan is attached) "/>
+  <arg name="scan_reduced_contact_links" default="['']" description="List of links whose minimum acceptable contact distance to the scan should be set to 0.0 (e.g., the TCP link)"/>
   <!-- Scan Link -->
   <arg name="collision_object_type" default="convex_mesh" description="Collision model representation for scan mesh (convex_mesh, mesh, octree)"/>
   <arg name="octree_resolution" default="0.010"/>


### PR DESCRIPTION
Empty list parameters are apparently not supported yet in ROS2 launch; see [here](https://github.com/ros2/rclcpp/issues/1955) for details. The planning node crashes due to an invalid parameter exception when it is passed an empty list for a parameter. The work around is to add an empty string entry in the list, which is hacky but doesn't cause problems