### PR TITLE
Expose stacked widget and text edit widget objects

### DIFF
--- a/snp_application/include/snp_application/snp_widget.h
+++ b/snp_application/include/snp_application/snp_widget.h
@@ -3,8 +3,6 @@
 #include <behaviortree_cpp/blackboard.h>
 #include <behaviortree_cpp/loggers/abstract_logger.h>
 #include <QWidget>
-#include <QTextEdit>
-#include <QStackedWidget>
 #include <rclcpp/node.hpp>
 #include <rclcpp_action/client.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
@@ -13,6 +11,9 @@ namespace Ui
 {
 class SNPWidget;
 }
+
+class QStackedWidget;
+class QTextEdit;
 
 namespace snp_application
 {
@@ -25,6 +26,8 @@ protected:
   void runTreeWithThread();
 
   virtual BT::BehaviorTreeFactory createBTFactory(int ros_short_timeout, int ros_long_timeout);
+  QStackedWidget* getStackedWidget();
+  QTextEdit* getTextEdit();
 
   rclcpp::Node::SharedPtr bt_node_;
   rclcpp::Node::SharedPtr tpp_node_;
@@ -33,8 +36,6 @@ protected:
   Ui::SNPWidget* ui_;
   BT::Blackboard::Ptr board_;
   std::shared_ptr<BT::StatusChangeLogger> logger_;
-  QStackedWidget* getStackedWidgetObject();
-  QTextEdit* getTextEditObject();
 };
 
 }  // namespace snp_application

--- a/snp_application/include/snp_application/snp_widget.h
+++ b/snp_application/include/snp_application/snp_widget.h
@@ -4,6 +4,7 @@
 #include <behaviortree_cpp/loggers/abstract_logger.h>
 #include <QWidget>
 #include <QTextEdit>
+#include <QStackedWidget>
 #include <rclcpp/node.hpp>
 #include <rclcpp_action/client.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
@@ -32,7 +33,7 @@ protected:
   Ui::SNPWidget* ui_;
   BT::Blackboard::Ptr board_;
   std::shared_ptr<BT::StatusChangeLogger> logger_;
-  QWidget* getStackedWidgetObject(int index);
+  QStackedWidget* getStackedWidgetObject();
   QTextEdit* getTextEditObject();
 };
 

--- a/snp_application/include/snp_application/snp_widget.h
+++ b/snp_application/include/snp_application/snp_widget.h
@@ -3,6 +3,7 @@
 #include <behaviortree_cpp/blackboard.h>
 #include <behaviortree_cpp/loggers/abstract_logger.h>
 #include <QWidget>
+#include <QTextEdit>
 #include <rclcpp/node.hpp>
 #include <rclcpp_action/client.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
@@ -31,6 +32,8 @@ protected:
   Ui::SNPWidget* ui_;
   BT::Blackboard::Ptr board_;
   std::shared_ptr<BT::StatusChangeLogger> logger_;
+  QWidget* getStackedWidgetObject(int index);
+  QTextEdit* getTextEditObject();
 };
 
 }  // namespace snp_application

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -243,14 +243,11 @@ QStackedWidget* SNPWidget::getStackedWidgetObject()
 {
   // return ui_->stacked_widget->widget(index);
   return ui_->stacked_widget;
-
 }
 
 QTextEdit* SNPWidget::getTextEditObject()
 {
   return ui_->text_edit_log;
 }
-
-
 
 }  // namespace snp_application

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -239,9 +239,11 @@ void SNPWidget::runTreeWithThread()
     return;
   }
 }
-QWidget* SNPWidget::getStackedWidgetObject(int index)
+QStackedWidget* SNPWidget::getStackedWidgetObject()
 {
-  return ui_->stacked_widget->widget(index);
+  // return ui_->stacked_widget->widget(index);
+  return ui_->stacked_widget;
+
 }
 
 QTextEdit* SNPWidget::getTextEditObject()

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -16,6 +16,8 @@
 #include <QMessageBox>
 #include <QTextStream>
 #include <QScrollBar>
+#include <QTextEdit>
+#include <QStackedWidget>
 #include <snp_tpp/tpp_widget.h>
 #include <trajectory_preview/trajectory_preview_widget.h>
 
@@ -239,13 +241,13 @@ void SNPWidget::runTreeWithThread()
     return;
   }
 }
-QStackedWidget* SNPWidget::getStackedWidgetObject()
+
+QStackedWidget* SNPWidget::getStackedWidget()
 {
-  // return ui_->stacked_widget->widget(index);
   return ui_->stacked_widget;
 }
 
-QTextEdit* SNPWidget::getTextEditObject()
+QTextEdit* SNPWidget::getTextEdit()
 {
   return ui_->text_edit_log;
 }

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -239,5 +239,16 @@ void SNPWidget::runTreeWithThread()
     return;
   }
 }
+QWidget* SNPWidget::getStackedWidgetObject(int index)
+{
+  return ui_->stacked_widget->widget(index);
+}
+
+QTextEdit* SNPWidget::getTextEditObject()
+{
+  return ui_->text_edit_log;
+}
+
+
 
 }  // namespace snp_application


### PR DESCRIPTION
- Created methods that expose stacked widget and text edit widget objects

This is useful for users that wish to add their own custom widgets to the existing snp application. 