### PR TITLE
Changed custom nodes from control to action nodes

### DIFF
--- a/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
@@ -304,7 +304,7 @@ public:
   BT::NodeStatus onResultReceived(const WrappedResult& result) override;
 };
 
-class UpdateTrajectoryStartStateNode : public BT::ControlNode
+class UpdateTrajectoryStartStateNode : public BT::ActionNodeBase
 {
 public:
   inline static std::string START_JOINT_STATE_INPUT_PORT_KEY = "joint_state";
@@ -321,11 +321,11 @@ public:
 
 protected:
   BT::NodeStatus tick() override;
-
+  void halt() override;
   rclcpp::Node::SharedPtr node_;
 };
 
-class ReverseTrajectoryNode : public BT::ControlNode
+class ReverseTrajectoryNode : public BT::ActionNodeBase
 {
 public:
   inline static std::string TRAJECTORY_INPUT_PORT_KEY = "input";
@@ -337,10 +337,12 @@ public:
   }
   explicit ReverseTrajectoryNode(const std::string& instance_name, const BT::NodeConfig& config);
 
+protected:
   BT::NodeStatus tick() override;
+  void halt() override;
 };
 
-class CombineTrajectoriesNode : public BT::ControlNode
+class CombineTrajectoriesNode : public BT::ActionNodeBase
 {
 public:
   inline static std::string FIRST_TRAJECTORY_INPUT_PORT_KEY = "first";
@@ -354,7 +356,9 @@ public:
   }
   explicit CombineTrajectoriesNode(const std::string& instance_name, const BT::NodeConfig& config);
 
+protected:
   BT::NodeStatus tick() override;
+  void halt() override;
 };
 
 class GetCurrentJointStateNode : public BT::RosTopicSubNode<sensor_msgs::msg::JointState>

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -444,7 +444,7 @@ BT::NodeStatus FollowJointTrajectoryActionNode::onResultReceived(const WrappedRe
 UpdateTrajectoryStartStateNode::UpdateTrajectoryStartStateNode(const std::string& instance_name,
                                                                const BT::NodeConfig& config,
                                                                rclcpp::Node::SharedPtr node)
-  : BT::ControlNode(instance_name, config), node_(node)
+  : BT::ActionNodeBase(instance_name, config), node_(node)
 {
 }
 
@@ -528,6 +528,10 @@ BT::NodeStatus UpdateTrajectoryStartStateNode::tick()
   return BT::NodeStatus::SUCCESS;
 }
 
+void UpdateTrajectoryStartStateNode::halt()
+{
+}
+
 /**
  * @details Adapted from
  * https://github.com/a5-robotics/A5/blob/1c1b280970722c6b41d997f91ef50ff1571eeeac/a5_utils/src/trajectories/trajectories.cpp#L77C4-L96
@@ -564,7 +568,7 @@ trajectory_msgs::msg::JointTrajectory reverseTrajectory(const trajectory_msgs::m
 }
 
 ReverseTrajectoryNode::ReverseTrajectoryNode(const std::string& instance_name, const BT::NodeConfig& config)
-  : BT::ControlNode(instance_name, config)
+  : BT::ActionNodeBase(instance_name, config)
 {
 }
 
@@ -595,8 +599,12 @@ BT::NodeStatus ReverseTrajectoryNode::tick()
   return BT::NodeStatus::SUCCESS;
 }
 
+void ReverseTrajectoryNode::halt()
+{
+}
+
 CombineTrajectoriesNode::CombineTrajectoriesNode(const std::string& instance_name, const BT::NodeConfig& config)
-  : BT::ControlNode(instance_name, config)
+  : BT::ActionNodeBase(instance_name, config)
 {
 }
 
@@ -638,6 +646,10 @@ BT::NodeStatus CombineTrajectoriesNode::tick()
   }
 
   return BT::NodeStatus::SUCCESS;
+}
+
+void CombineTrajectoriesNode::halt()
+{
 }
 
 BT::NodeStatus GetCurrentJointStateNode::onTick(const typename sensor_msgs::msg::JointState::SharedPtr& last_msg)


### PR DESCRIPTION
Changes per commit message. Control nodes are intended to control a sequence of child nodes. The custom nodes changed in this PR are more in line with regular action nodes.