### PR TITLE
Improved Motion Planning debugging

### DIFF
--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -32,7 +32,7 @@ task_composer_plugins:
       TaskflowExecutor:
         class: TaskflowTaskComposerExecutorFactory
         config:
-          threads: 2
+          threads: 8
   tasks:
     plugins:    
       SNPCartesianPipeline:

--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -19,7 +19,7 @@ KinematicLimitsCheckTask: &limits_check
   class: KinematicLimitsCheckTaskFactory
   config:
     conditional: true
-    inputs: [speed_param_output_data]
+    inputs: [output_data]
     outputs: [output_data]
 
 # Task composer configuration
@@ -61,7 +61,7 @@ task_composer_plugins:
               config:
                 conditional: true
                 inputs: [trajopt_output_data]
-                outputs: [speed_param_output_data]
+                outputs: [output_data]
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
@@ -83,25 +83,25 @@ task_composer_plugins:
           nodes:
             DoneTask: *done
             ErrorTask: *error
-            MinLengthTask:
-              class: MinLengthTaskFactory
-              config:
-                conditional: true
-                inputs: [input_data]
-                outputs: [min_len_output_data]
-                format_result_as_input: false
             OMPLMotionPlannerTask:
               class: OMPLMotionPlannerTaskFactory
               config:
                 conditional: true
-                inputs: [min_len_output_data]
+                inputs: [input_data]
                 outputs: [ompl_output_data]
                 format_result_as_input: true
+            MinLengthTask:
+              class: MinLengthTaskFactory
+              config:
+                conditional: true
+                inputs: [ompl_output_data]
+                outputs: [min_len_output_data]
+                format_result_as_input: false
             TrajOptMotionPlannerTask:
               class: TrajOptMotionPlannerTaskFactory
               config:
                 conditional: true
-                inputs: [ompl_output_data]
+                inputs: [min_len_output_data]
                 outputs: [trajopt_output_data]
                 format_result_as_input: false
             DiscreteContactCheckTask:
@@ -114,12 +114,12 @@ task_composer_plugins:
               config:
                 conditional: true
                 inputs: [trajopt_output_data]
-                outputs: [speed_param_output_data]
+                outputs: [output_data]
             KinematicLimitsCheckTask: *limits_check
           edges:
-            - source: MinLengthTask
-              destinations: [ErrorTask, OMPLMotionPlannerTask]
             - source: OMPLMotionPlannerTask
+              destinations: [ErrorTask, MinLengthTask]
+            - source: MinLengthTask
               destinations: [ErrorTask, TrajOptMotionPlannerTask]
             - source: TrajOptMotionPlannerTask
               destinations: [ErrorTask, DiscreteContactCheckTask]
@@ -168,13 +168,13 @@ task_composer_plugins:
               config:
                 conditional: true
                 inputs: [trajopt_output_data]
-                outputs: [speed_param_output_data]
+                outputs: [output_data]
             IterativeSplineParameterizationTask_OMPL:
               class: IterativeSplineParameterizationTaskFactory
               config:
                 conditional: true
                 inputs: [ompl_output_data]
-                outputs: [speed_param_output_data]
+                outputs: [output_data]
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
@@ -227,7 +227,6 @@ task_composer_plugins:
                       - min_len_output_data
                       - trajopt_output_data
                       - ompl_output_data
-                      - speed_param_output_data
                 raster:
                   task: SNPCartesianPipeline
                   config:
@@ -239,7 +238,6 @@ task_composer_plugins:
                       - output_data
                       - min_len_output_data
                       - trajopt_output_data
-                      - speed_param_output_data
                 transition:
                   task: SNPTransitionPipeline
                   config:
@@ -252,7 +250,6 @@ task_composer_plugins:
                       - min_len_output_data
                       - trajopt_output_data
                       - ompl_output_data
-                      - speed_param_output_data
             TCPSpeedLimiterTask:
               class: TCPSpeedLimiterTaskFactory
               config:

--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -13,37 +13,13 @@ MinLengthTask: &min_length
   config:
     conditional: true
     inputs: [input_data]
-    outputs: [output_data]
+    outputs: [min_len_output_data]
     format_result_as_input: false
-TrajOptMotionPlannerTask: &trajopt
-  class: TrajOptMotionPlannerTaskFactory
-  config:
-    conditional: true
-    inputs: [output_data]
-    outputs: [output_data]
-    format_result_as_input: false
-DiscreteContactCheckTask: &contact_check
-  class: DiscreteContactCheckTaskFactory
-  config:
-    conditional: true
-    inputs: [output_data]
-ConstantTCPSpeedTimeParameterizationTask: &constant_tcp_speed
-  class: ConstantTCPSpeedTimeParameterizationTaskFactory
-  config:
-    conditional: true
-    inputs: [output_data]
-    outputs: [output_data]
-IterativeSplineParameterizationTask: &isp
-  class: IterativeSplineParameterizationTaskFactory
-  config:
-    conditional: true
-    inputs: [output_data]
-    outputs: [output_data]
 KinematicLimitsCheckTask: &limits_check
   class: KinematicLimitsCheckTaskFactory
   config:
     conditional: true
-    inputs: [output_data]
+    inputs: [speed_param_output_data]
     outputs: [output_data]
 
 # Task composer configuration
@@ -56,7 +32,7 @@ task_composer_plugins:
       TaskflowExecutor:
         class: TaskflowTaskComposerExecutorFactory
         config:
-          threads: 8
+          threads: 2
   tasks:
     plugins:    
       SNPCartesianPipeline:
@@ -68,9 +44,24 @@ task_composer_plugins:
             DoneTask: *done
             ErrorTask: *error
             MinLengthTask: *min_length
-            TrajOptMotionPlannerTask: *trajopt
-            DiscreteContactCheckTask: *contact_check
-            ConstantTCPSpeedTimeParameterizationTask: *constant_tcp_speed
+            TrajOptMotionPlannerTask:
+              class: TrajOptMotionPlannerTaskFactory
+              config:
+                conditional: true
+                inputs: [min_len_output_data]
+                outputs: [trajopt_output_data]
+                format_result_as_input: false
+            DiscreteContactCheckTask:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                conditional: true
+                inputs: [trajopt_output_data]
+            ConstantTCPSpeedTimeParameterizationTask:
+              class: ConstantTCPSpeedTimeParameterizationTaskFactory
+              config:
+                conditional: true
+                inputs: [trajopt_output_data]
+                outputs: [speed_param_output_data]
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
@@ -92,17 +83,38 @@ task_composer_plugins:
           nodes:
             DoneTask: *done
             ErrorTask: *error
-            MinLengthTask: *min_length
+            MinLengthTask:
+              class: MinLengthTaskFactory
+              config:
+                conditional: true
+                inputs: [input_data]
+                outputs: [min_len_output_data]
+                format_result_as_input: false
             OMPLMotionPlannerTask:
               class: OMPLMotionPlannerTaskFactory
               config:
                 conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
+                inputs: [min_len_output_data]
+                outputs: [ompl_output_data]
                 format_result_as_input: true
-            TrajOptMotionPlannerTask: *trajopt
-            DiscreteContactCheckTask: *contact_check
-            IterativeSplineParameterizationTask: *isp
+            TrajOptMotionPlannerTask:
+              class: TrajOptMotionPlannerTaskFactory
+              config:
+                conditional: true
+                inputs: [ompl_output_data]
+                outputs: [trajopt_output_data]
+                format_result_as_input: false
+            DiscreteContactCheckTask:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                conditional: true
+                inputs: [trajopt_output_data]
+            IterativeSplineParameterizationTask:
+              class: IterativeSplineParameterizationTaskFactory
+              config:
+                conditional: true
+                inputs: [trajopt_output_data]
+                outputs: [speed_param_output_data]
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
@@ -127,27 +139,57 @@ task_composer_plugins:
             DoneTask: *done
             ErrorTask: *error
             MinLengthTask: *min_length
-            TrajOptMotionPlannerTask: *trajopt
+            TrajOptMotionPlannerTask:
+              class: TrajOptMotionPlannerTaskFactory
+              config:
+                conditional: true
+                inputs: [min_len_output_data]
+                outputs: [trajopt_output_data]
+                format_result_as_input: false
             OMPLMotionPlannerTask:
               class: OMPLMotionPlannerTaskFactory
               config:
                 conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
+                inputs: [input_data]
+                outputs: [ompl_output_data]
                 format_result_as_input: false
-            DiscreteContactCheckTask: *contact_check
-            IterativeSplineParameterizationTask: *isp
+            DiscreteContactCheckTask_TrajOpt:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                conditional: true
+                inputs: [trajopt_output_data]
+            DiscreteContactCheckTask_OMPL:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                conditional: true
+                inputs: [ompl_output_data]
+            IterativeSplineParameterizationTask_TrajOpt:
+              class: IterativeSplineParameterizationTaskFactory
+              config:
+                conditional: true
+                inputs: [trajopt_output_data]
+                outputs: [speed_param_output_data]
+            IterativeSplineParameterizationTask_OMPL:
+              class: IterativeSplineParameterizationTaskFactory
+              config:
+                conditional: true
+                inputs: [ompl_output_data]
+                outputs: [speed_param_output_data]
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
               destinations: [ErrorTask, TrajOptMotionPlannerTask]
             - source: TrajOptMotionPlannerTask
-              destinations: [OMPLMotionPlannerTask, DiscreteContactCheckTask]
+              destinations: [OMPLMotionPlannerTask, DiscreteContactCheckTask_TrajOpt]
+            - source: DiscreteContactCheckTask_TrajOpt
+              destinations: [OMPLMotionPlannerTask, IterativeSplineParameterizationTask_TrajOpt]
+            - source: IterativeSplineParameterizationTask_TrajOpt
+              destinations: [ErrorTask, KinematicLimitsCheckTask]
             - source: OMPLMotionPlannerTask
-              destinations: [ErrorTask, DiscreteContactCheckTask]
-            - source: DiscreteContactCheckTask
-              destinations: [ErrorTask, IterativeSplineParameterizationTask]
-            - source: IterativeSplineParameterizationTask
+              destinations: [ErrorTask, DiscreteContactCheckTask_OMPL]
+            - source: DiscreteContactCheckTask_OMPL
+              destinations: [ErrorTask, IterativeSplineParameterizationTask_OMPL]
+            - source: IterativeSplineParameterizationTask_OMPL
               destinations: [ErrorTask, KinematicLimitsCheckTask]
             - source: KinematicLimitsCheckTask
               destinations: [ErrorTask, DoneTask]
@@ -160,47 +202,57 @@ task_composer_plugins:
           nodes:
             DoneTask: *done
             ErrorTask: *error
-            SimpleMotionPlannerTask:
-              class: SimpleMotionPlannerTaskFactory
-              config:
-                conditional: true
-                inputs: [input_data]
-                outputs: [output_data]
-                format_result_as_input: true
             DescartesMotionPlannerTask:
               class: DescartesFMotionPlannerTaskFactory
               config:
                 conditional: true
-                inputs: [output_data]
-                outputs: [output_data]
+                inputs: [input_data]
+                outputs: [descartes_output_data]
                 format_result_as_input: true
             RasterMotionTask:
               class: RasterMotionTaskFactory
               config:
                 conditional: true
-                inputs: [output_data]
+                inputs: [descartes_output_data]
                 outputs: [output_data]
                 freespace:
                   task: SNPFreespacePipeline
                   config:
                     remapping:
-                      input_data: output_data
+                      input_data: input_data
                       output_data: output_data
-                    indexing: [output_data]
+                    indexing:
+                      - input_data
+                      - output_data
+                      - min_len_output_data
+                      - trajopt_output_data
+                      - ompl_output_data
+                      - speed_param_output_data
                 raster:
                   task: SNPCartesianPipeline
                   config:
                     remapping:
-                      input_data: output_data
+                      input_data: input_data
                       output_data: output_data
-                    indexing: [output_data]
+                    indexing:
+                      - input_data
+                      - output_data
+                      - min_len_output_data
+                      - trajopt_output_data
+                      - speed_param_output_data
                 transition:
                   task: SNPTransitionPipeline
                   config:
                     remapping:
-                      input_data: output_data
+                      input_data: input_data
                       output_data: output_data
-                    indexing: [output_data]
+                    indexing:
+                      - input_data
+                      - output_data
+                      - min_len_output_data
+                      - trajopt_output_data
+                      - ompl_output_data
+                      - speed_param_output_data
             TCPSpeedLimiterTask:
               class: TCPSpeedLimiterTaskFactory
               config:
@@ -208,8 +260,6 @@ task_composer_plugins:
                 inputs: [output_data]
                 outputs: [output_data]
           edges:
-            - source: SimpleMotionPlannerTask
-              destinations: [ErrorTask, DescartesMotionPlannerTask]
             - source: DescartesMotionPlannerTask
               destinations: [ErrorTask, RasterMotionTask]
             - source: RasterMotionTask

--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -26,8 +26,8 @@
   <arg name="contact_check_lvs_distance" default="0.05"/>
   <arg name="ompl_max_planning_time" default="5.0"/>
   <arg name="tcp_max_speed" default="0.25"/>
-  <arg name="cartesian_tolerance" default="[0.01, 0.01, 0.01, 0.05, 0.05, 6.28]"/>
-  <arg name="cartesian_coefficient" default="[2.5, 2.5, 2.5, 2.5, 2.5, 0.0]"/>
+  <arg name="cartesian_tolerance" default="[0.01, 0.01, 0.001, 0.05, 0.05, 6.28]"/>
+  <arg name="cartesian_coefficient" default="[5.0, 5.0, 5.0, 5.0, 5.0, 0.0]"/>
 
   <node pkg="snp_motion_planning" exec="snp_motion_planning_node" output="screen">
     <!-- General -->

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -170,7 +170,7 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
 
   profile->contact_test_type = tesseract_collision::ContactTestType::CLOSEST;
 
-  profile->collision_cost_config.enabled = true;
+  profile->collision_cost_config.enabled = false;
   profile->collision_cost_config.type = trajopt::CollisionEvaluatorType::DISCRETE_CONTINUOUS;
   profile->collision_cost_config.safety_margin = min_contact_distance;
   profile->collision_cost_config.safety_margin_buffer = std::max(0.020, 2 * min_contact_distance);
@@ -182,7 +182,11 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
     profile->special_collision_cost->setPairSafetyMarginData(pair.first, pair.second, pair.distance,
                                                              profile->collision_cost_config.coeff);
 
-  profile->collision_constraint_config.enabled = false;
+  profile->collision_constraint_config.enabled = true;
+  profile->collision_constraint_config.type = trajopt::CollisionEvaluatorType::DISCRETE_CONTINUOUS;
+  profile->collision_constraint_config.safety_margin = min_contact_distance;
+  profile->collision_constraint_config.safety_margin_buffer = std::max(0.020, 2 * min_contact_distance);
+  profile->collision_constraint_config.coeff = 10.0;
 
   return profile;
 }

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -545,8 +545,7 @@ private:
     // Save results dot graph
     std::filesystem::path results_dot("Results.dot");
     std::ofstream tc_out_results(debug_directory / results_dot);
-          static_cast<const tesseract_planning::TaskComposerGraph&>(*task).dump(tc_out_results, nullptr,
-                                                                                result->context->task_infos.getInfoMap());
+    task->dump(tc_out_results, nullptr, result->context->task_infos.getInfoMap());
   }
 
   tesseract_planning::CompositeInstruction plan(const tesseract_planning::CompositeInstruction& program,

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -538,8 +538,9 @@ private:
         intermediate_ci_dir / std::filesystem::path(key +".xml"));
 
       tesseract_common::JointTrajectory traj_debug = toJointTrajectory(ci_debug);
-      plotter_->plotTrajectory(traj_debug, "DEBUG_" + time_stamp, key);
       traj_debug.description = key;
+      plotter_->plotTrajectory(traj_debug, "DEBUG_" + time_stamp, key);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
     // Save results dot graph

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -503,6 +503,52 @@ private:
     return profile_dict;
   }
 
+  void storeAndPlotDebugTrajectories(const tesseract_planning::TaskComposerNode::UPtr& task,
+                                     const tesseract_planning::TaskComposerFuture::UPtr& result)
+  {
+    // Make debug directory
+    std::string time_stamp = tesseract_common::getTimestampString();
+    std::filesystem::path tmp_directory("/tmp");
+    std::filesystem::path snp_parent_dir("SNP_Planning");
+    std::filesystem::path timestamped_dir("Plan_" + time_stamp);
+    std::filesystem::path debug_directory = tmp_directory / snp_parent_dir / timestamped_dir;
+    std::filesystem::create_directories(debug_directory);
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Saving to: " << debug_directory);
+
+    // Add debug trajectories to be plottable
+    auto all_data = result->context->data_storage->getData();
+
+    // Sort data keys for easier debugging
+    std::vector<std::string> data_keys;
+    for (const auto & pair : all_data) {
+      data_keys.push_back(pair.first);
+    }
+    std::sort(data_keys.begin(), data_keys.end());
+
+    // Store each intermediate CI
+    for (const auto & key : data_keys) {
+      auto ci_debug =
+        result->context->data_storage->getData(key).as<tesseract_planning::CompositeInstruction>();
+
+      // Save all raw CI's to aid with debugging if necessary
+      std::filesystem::path intermediate_ci_dir = debug_directory / std::filesystem::path("intermediate_ci");
+      std::filesystem::create_directories(intermediate_ci_dir);
+      tesseract_common::Serialization::toArchiveFileXML(
+        ci_debug,
+        intermediate_ci_dir / std::filesystem::path(key +".xml"));
+
+      tesseract_common::JointTrajectory traj_debug = toJointTrajectory(ci_debug);
+      plotter_->plotTrajectory(traj_debug, "DEBUG_" + time_stamp, key);
+      traj_debug.description = key;
+    }
+
+    // Save results dot graph
+    std::filesystem::path results_dot("Results.dot");
+    std::ofstream tc_out_results(debug_directory / results_dot);
+          static_cast<const tesseract_planning::TaskComposerGraph&>(*task).dump(tc_out_results, nullptr,
+                                                                                result->context->task_infos.getInfoMap());
+  }
+
   tesseract_planning::CompositeInstruction plan(const tesseract_planning::CompositeInstruction& program,
                                                 tesseract_planning::ProfileDictionary::Ptr profile_dict,
                                                 const std::string& task_name)
@@ -555,51 +601,7 @@ private:
     result->wait();
 
     // Save the output motion planning data
-    {
-        // Make debug directory
-        std::string time_stamp = tesseract_common::getTimestampString();
-        std::filesystem::path tmp_directory("/tmp");
-        std::filesystem::path snp_parent_dir("SNP_Planning");
-        std::filesystem::path timestamped_dir("Plan_" + time_stamp);
-        std::filesystem::path debug_directory = tmp_directory / snp_parent_dir / timestamped_dir;
-        std::filesystem::create_directories(debug_directory);
-        RCLCPP_INFO_STREAM(node_->get_logger(), "Saving to: " << debug_directory);
-
-        // Add debug trajectories to be plottable
-        std::vector<tesseract_common::JointTrajectory> debug_trajectories;
-        auto all_data = result->context->data_storage->getData();
-
-        // Sort data keys for easier debugging
-        std::vector<std::string> data_keys;
-        for (const auto & pair : all_data) {
-          data_keys.push_back(pair.first);
-        }
-        std::sort(data_keys.begin(), data_keys.end());
-
-        // Store each intermediate CI
-        for (const auto & key : data_keys) {
-          auto ci_debug =
-            result->context->data_storage->getData(key).as<tesseract_planning::CompositeInstruction>();
-
-          // Save all raw CI's to aid with debugging if necessary
-          std::filesystem::path intermediate_ci_dir = debug_directory / std::filesystem::path("intermediate_ci");
-          std::filesystem::create_directories(intermediate_ci_dir);
-          tesseract_common::Serialization::toArchiveFileXML(
-            ci_debug,
-            intermediate_ci_dir / std::filesystem::path(key +".xml"));
-
-          tesseract_common::JointTrajectory traj_debug = toJointTrajectory(ci_debug);
-          plotter_->plotTrajectory(traj_debug, "DEBUG_" + time_stamp, key);
-          traj_debug.description = key;
-          debug_trajectories.push_back(traj_debug);
-        }
-
-        // Save results dot graph
-        std::filesystem::path results_dot("Results.dot");
-        std::ofstream tc_out_results(debug_directory / results_dot);
-              static_cast<const tesseract_planning::TaskComposerGraph&>(*task).dump(tc_out_results, nullptr,
-                                                                                    result->context->task_infos.getInfoMap());
-    }
+    storeAndPlotDebugTrajectories(task, result);
 
     // Reset the log level
     console_bridge::setLogLevel(log_level);


### PR DESCRIPTION
Improvements to the debugging for motion planning.
- Save all motion plan results to a time stamped directory
```
/tmp/SNP_Planning
├── Plan02-08-2024-10-47-30
│   ├── Results.dot
│   └── intermediate_ci
│       ├── SNPCartesianPipeline_input_data1.xml
│       ├── SNPCartesianPipeline_input_data2.xml
│       ├── SNPCartesianPipeline_input_data3.xml
│       ├── SNPCartesianPipeline_min_len_output_data3.xml
│       ├── SNPCartesianPipeline_speed_param_output_data3.xml
│       ├── SNPCartesianPipeline_trajopt_output_data3.xml
│       ├── SNPFreespacePipeline_input_data0.xml
│       ├── SNPFreespacePipeline_input_data7.xml
│       ├── SNPFreespacePipeline_ompl_output_data7.xml
│       ├── SNPTransitionPipeline_input_data1.xml
│       ├── SNPTransitionPipeline_input_data2.xml
│       ├── descartes_output_data.xml
│       └── input_data.xml
```
- Allow for RVIZ introspection of individual planning steps
![image](https://github.com/user-attachments/assets/d46bdf9a-4b9e-4e33-a72d-388bc4d19dfb)

- Some other minor motion planning improvements
