### PR TITLE
Behavior tree plugins

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,7 +25,7 @@ NamespaceIndentation: None
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 60
-PenaltyBreakString: 1
+PenaltyBreakString: 100
 PenaltyBreakFirstLessLess: 1000
 PenaltyExcessCharacter: 1000
 PenaltyReturnTypeOnItsOwnLine: 90

--- a/snp_application/CMakeLists.txt
+++ b/snp_application/CMakeLists.txt
@@ -30,24 +30,44 @@ find_package(control_msgs REQUIRED)
 find_package(snp_msgs REQUIRED)
 find_package(snp_tpp REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(tf2_eigen REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(trajectory_preview REQUIRED)
 
 add_library(
-  ${PROJECT_NAME}_widget SHARED
-  src/snp_widget.ui
-  src/snp_widget.cpp
-  # BT
-  src/bt/bt_thread.cpp
+  ${PROJECT_NAME}_bt_plugins SHARED
   src/bt/button_approval_node.cpp
   src/bt/button_monitor_node.cpp
   src/bt/progress_decorator_node.cpp
   src/bt/set_page_decorator_node.cpp
   src/bt/snp_bt_ros_nodes.cpp
   src/bt/snp_sequence_with_memory_node.cpp
+  src/bt/plugins.cpp)
+target_compile_definitions(${PROJECT_NAME}_bt_plugins PRIVATE BT_PLUGIN_EXPORT)
+target_include_directories(${PROJECT_NAME}_bt_plugins PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                             "$<INSTALL_INTERFACE:include>" ${EIGEN3_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_bt_plugins Qt5::Widgets)
+ament_target_dependencies(
+  ${PROJECT_NAME}_bt_plugins
+  behaviortree_cpp
+  behaviortree_ros2
+  industrial_reconstruction_msgs
+  rclcpp_action
+  control_msgs
+  sensor_msgs
+  geometry_msgs
+  snp_msgs
+  std_srvs
+  trajectory_msgs)
+
+# Widget
+add_library(
+  ${PROJECT_NAME}_widget SHARED
+  src/snp_widget.ui
+  src/snp_widget.cpp
+  # BT
+  src/bt/bt_thread.cpp
   src/bt/text_edit_logger.cpp)
 target_include_directories(
   ${PROJECT_NAME}_widget
@@ -60,17 +80,8 @@ ament_target_dependencies(
   ${PROJECT_NAME}_widget
   behaviortree_cpp
   behaviortree_ros2
-  industrial_reconstruction_msgs
-  rclcpp_action
-  rclcpp_components
-  control_msgs
   sensor_msgs
-  geometry_msgs
-  snp_msgs
   snp_tpp
-  std_srvs
-  tf2_eigen
-  trajectory_msgs
   trajectory_preview)
 
 add_library(${PROJECT_NAME}_panel SHARED src/snp_panel.cpp)
@@ -85,7 +96,8 @@ ament_target_dependencies(roscon_app rclcpp)
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION include/)
 
 # Install the library(ies)
-install(TARGETS ${PROJECT_NAME}_widget ${PROJECT_NAME}_panel EXPORT ${PROJECT_NAME}-targets DESTINATION lib)
+install(TARGETS ${PROJECT_NAME}_bt_plugins ${PROJECT_NAME}_widget ${PROJECT_NAME}_panel EXPORT ${PROJECT_NAME}-targets
+        DESTINATION lib)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 
 install(TARGETS roscon_app DESTINATION lib/${PROJECT_NAME}/)
@@ -105,7 +117,6 @@ ament_export_dependencies(
   snp_msgs
   snp_tpp
   std_srvs
-  tf2_eigen
   trajectory_msgs
   trajectory_preview
   rviz_common

--- a/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
@@ -20,52 +20,6 @@
 
 namespace snp_application
 {
-// Parameters
-static const std::string MOTION_GROUP_PARAM = "motion_group";
-static const std::string REF_FRAME_PARAM = "reference_frame";
-static const std::string TCP_FRAME_PARAM = "tcp_frame";
-static const std::string CAMERA_FRAME_PARAM = "camera_frame";
-static const std::string MESH_FILE_PARAM = "mesh_file";
-static const std::string START_STATE_REPLACEMENT_TOLERANCE_PARAM = "start_state_replacement_tolerance";
-// Home state
-static const std::string HOME_STATE_JOINT_VALUES_PARAM = "home_state_joint_values";
-static const std::string HOME_STATE_JOINT_NAMES_PARAM = "home_state_joint_names";
-//   Industrial Reconstruction
-static const std::string IR_TSDF_VOXEL_PARAM = "ir.tsdf.voxel_length";
-static const std::string IR_TSDF_SDF_PARAM = "ir.tsdf.sdf_trunc";
-static const std::string IR_TSDF_MIN_X_PARAM = "ir.tsdf.min.x";
-static const std::string IR_TSDF_MIN_Y_PARAM = "ir.tsdf.min.y";
-static const std::string IR_TSDF_MIN_Z_PARAM = "ir.tsdf.min.z";
-static const std::string IR_TSDF_MAX_X_PARAM = "ir.tsdf.max.x";
-static const std::string IR_TSDF_MAX_Y_PARAM = "ir.tsdf.max.y";
-static const std::string IR_TSDF_MAX_Z_PARAM = "ir.tsdf.max.z";
-static const std::string IR_RGBD_DEPTH_SCALE_PARAM = "ir.rgbd.depth_scale";
-static const std::string IR_RGBD_DEPTH_TRUNC_PARAM = "ir.rgbd.depth_trunc";
-static const std::string IR_LIVE_PARAM = "ir.live";
-static const std::string IR_MIN_FACES_PARAM = "ir.min_faces";
-static const std::string IR_NORMAL_ANGLE_TOL_PARAM = "ir.normal_angle_tol";
-static const std::string IR_NORMAL_X_PARAM = "ir.normal_x";
-static const std::string IR_NORMAL_Y_PARAM = "ir.normal_y";
-static const std::string IR_NORMAL_Z_PARAM = "ir.normal_z";
-static const std::string IR_ARCHIVE_DIR_PARAM = "ir.archive_dir";
-
-template <typename T>
-T get_parameter(rclcpp::Node::SharedPtr node, const std::string& key)
-{
-  T val;
-  if (!node->get_parameter(key, val))
-    throw std::runtime_error("Failed to get '" + key + "' parameter");
-  return val;
-}
-
-template <typename T>
-T get_parameter_or(rclcpp::Node::SharedPtr node, const std::string& key, const T& default_val)
-{
-  T val;
-  node->get_parameter_or(key, val, default_val);
-  return val;
-}
-
 template <typename T>
 class SnpRosServiceNode : public BT::RosServiceNode<T>
 {

--- a/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
@@ -304,7 +304,7 @@ public:
   BT::NodeStatus onResultReceived(const WrappedResult& result) override;
 };
 
-class UpdateTrajectoryStartStateNode : public BT::ActionNodeBase
+class UpdateTrajectoryStartStateNode : public BT::SyncActionNode
 {
 public:
   inline static std::string START_JOINT_STATE_INPUT_PORT_KEY = "joint_state";
@@ -321,11 +321,10 @@ public:
 
 protected:
   BT::NodeStatus tick() override;
-  void halt() override;
   rclcpp::Node::SharedPtr node_;
 };
 
-class ReverseTrajectoryNode : public BT::ActionNodeBase
+class ReverseTrajectoryNode : public BT::SyncActionNode
 {
 public:
   inline static std::string TRAJECTORY_INPUT_PORT_KEY = "input";
@@ -339,10 +338,9 @@ public:
 
 protected:
   BT::NodeStatus tick() override;
-  void halt() override;
 };
 
-class CombineTrajectoriesNode : public BT::ActionNodeBase
+class CombineTrajectoriesNode : public BT::SyncActionNode
 {
 public:
   inline static std::string FIRST_TRAJECTORY_INPUT_PORT_KEY = "first";
@@ -358,7 +356,6 @@ public:
 
 protected:
   BT::NodeStatus tick() override;
-  void halt() override;
 };
 
 class GetCurrentJointStateNode : public BT::RosTopicSubNode<sensor_msgs::msg::JointState>

--- a/snp_application/include/snp_application/bt/utils.h
+++ b/snp_application/include/snp_application/bt/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <behaviortree_cpp/tree_node.h>
+#include <rclcpp/node.hpp>
 
 namespace snp_application
 {
@@ -15,6 +16,52 @@ T getBTInput(const BT::TreeNode* node, const std::string& port)
     throw BT::RuntimeError("Failed to get required input value: '" + input.error() + "'");
 
   return input.value();
+}
+
+// Parameters
+static const std::string MOTION_GROUP_PARAM = "motion_group";
+static const std::string REF_FRAME_PARAM = "reference_frame";
+static const std::string TCP_FRAME_PARAM = "tcp_frame";
+static const std::string CAMERA_FRAME_PARAM = "camera_frame";
+static const std::string MESH_FILE_PARAM = "mesh_file";
+static const std::string START_STATE_REPLACEMENT_TOLERANCE_PARAM = "start_state_replacement_tolerance";
+// Home state
+static const std::string HOME_STATE_JOINT_VALUES_PARAM = "home_state_joint_values";
+static const std::string HOME_STATE_JOINT_NAMES_PARAM = "home_state_joint_names";
+//   Industrial Reconstruction
+static const std::string IR_TSDF_VOXEL_PARAM = "ir.tsdf.voxel_length";
+static const std::string IR_TSDF_SDF_PARAM = "ir.tsdf.sdf_trunc";
+static const std::string IR_TSDF_MIN_X_PARAM = "ir.tsdf.min.x";
+static const std::string IR_TSDF_MIN_Y_PARAM = "ir.tsdf.min.y";
+static const std::string IR_TSDF_MIN_Z_PARAM = "ir.tsdf.min.z";
+static const std::string IR_TSDF_MAX_X_PARAM = "ir.tsdf.max.x";
+static const std::string IR_TSDF_MAX_Y_PARAM = "ir.tsdf.max.y";
+static const std::string IR_TSDF_MAX_Z_PARAM = "ir.tsdf.max.z";
+static const std::string IR_RGBD_DEPTH_SCALE_PARAM = "ir.rgbd.depth_scale";
+static const std::string IR_RGBD_DEPTH_TRUNC_PARAM = "ir.rgbd.depth_trunc";
+static const std::string IR_LIVE_PARAM = "ir.live";
+static const std::string IR_MIN_FACES_PARAM = "ir.min_faces";
+static const std::string IR_NORMAL_ANGLE_TOL_PARAM = "ir.normal_angle_tol";
+static const std::string IR_NORMAL_X_PARAM = "ir.normal_x";
+static const std::string IR_NORMAL_Y_PARAM = "ir.normal_y";
+static const std::string IR_NORMAL_Z_PARAM = "ir.normal_z";
+static const std::string IR_ARCHIVE_DIR_PARAM = "ir.archive_dir";
+
+template <typename T>
+T get_parameter(rclcpp::Node::SharedPtr node, const std::string& key)
+{
+  T val;
+  if (!node->get_parameter(key, val))
+    throw std::runtime_error("Failed to get '" + key + "' parameter");
+  return val;
+}
+
+template <typename T>
+T get_parameter_or(rclcpp::Node::SharedPtr node, const std::string& key, const T& default_val)
+{
+  T val;
+  node->get_parameter_or(key, val, default_val);
+  return val;
 }
 
 }  // namespace snp_application

--- a/snp_application/include/snp_application/bt/utils.h
+++ b/snp_application/include/snp_application/bt/utils.h
@@ -20,6 +20,7 @@ T getBTInput(const BT::TreeNode* node, const std::string& port)
 
 // Parameters
 static const std::string MOTION_GROUP_PARAM = "motion_group";
+static const std::string FREESPACE_MOTION_GROUP_PARAM = "freespace_motion_group";
 static const std::string REF_FRAME_PARAM = "reference_frame";
 static const std::string TCP_FRAME_PARAM = "tcp_frame";
 static const std::string CAMERA_FRAME_PARAM = "camera_frame";

--- a/snp_application/include/snp_application/snp_widget.h
+++ b/snp_application/include/snp_application/snp_widget.h
@@ -25,7 +25,7 @@ public:
 protected:
   void runTreeWithThread(const std::string& bt_tree_name);
 
-  virtual BT::BehaviorTreeFactory createBTFactory(int ros_short_timeout, int ros_long_timeout);
+  virtual BT::BehaviorTreeFactory createBTFactory(int ros_timeout);
   QStackedWidget* getStackedWidget();
   QTextEdit* getTextEdit();
 

--- a/snp_application/package.xml
+++ b/snp_application/package.xml
@@ -23,7 +23,6 @@
   <depend>std_srvs</depend>
   <depend>rviz_common</depend>
   <depend>pluginlib</depend>
-  <depend>tf2_eigen</depend>
   <depend>trajectory_preview</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/snp_application/src/bt/plugins.cpp
+++ b/snp_application/src/bt/plugins.cpp
@@ -8,6 +8,13 @@
 
 #include <behaviortree_cpp/bt_factory.h>
 
+template<typename T>
+void try_declare_parameter(rclcpp::Node::SharedPtr node, const std::string& key, const T& value)
+{
+  if (!node->has_parameter(key))
+    node->declare_parameter(key, value);
+}
+
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<snp_application::ButtonApprovalNode>("ButtonApproval");
@@ -37,37 +44,37 @@ BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory,
 
   // Nodes requiring parameters
   // Update trajectory start state
-  params.nh->declare_parameter<double>(START_STATE_REPLACEMENT_TOLERANCE_PARAM, 1.0 * M_PI / 180.0);
+  try_declare_parameter<double>(params.nh, START_STATE_REPLACEMENT_TOLERANCE_PARAM, 1.0 * M_PI / 180.0);
   factory.registerNodeType<snp_application::UpdateTrajectoryStartStateNode>("UpdateTrajectoryStartState", params.nh);
 
   // Motion plan generation
-  params.nh->declare_parameter<std::string>(MOTION_GROUP_PARAM, "");
-  params.nh->declare_parameter<std::string>(REF_FRAME_PARAM, "");
-  params.nh->declare_parameter<std::string>(TCP_FRAME_PARAM, "");
+  try_declare_parameter<std::string>(params.nh, MOTION_GROUP_PARAM, "");
+  try_declare_parameter<std::string>(params.nh, REF_FRAME_PARAM, "");
+  try_declare_parameter<std::string>(params.nh, TCP_FRAME_PARAM, "");
   factory.registerNodeType<snp_application::GenerateMotionPlanServiceNode>("GenerateMotionPlanService", params);
 
-  // Industrial reconstruction start
-  params.nh->declare_parameter<std::string>(CAMERA_FRAME_PARAM, "");
-  params.nh->declare_parameter<float>(IR_TSDF_VOXEL_PARAM, 0.01f);
-  params.nh->declare_parameter<float>(IR_TSDF_SDF_PARAM, 0.03f);
-  params.nh->declare_parameter<double>(IR_TSDF_MIN_X_PARAM, 0.0);
-  params.nh->declare_parameter<double>(IR_TSDF_MIN_Y_PARAM, 0.0);
-  params.nh->declare_parameter<double>(IR_TSDF_MIN_Z_PARAM, 0.0);
-  params.nh->declare_parameter<double>(IR_TSDF_MAX_X_PARAM, 0.0);
-  params.nh->declare_parameter<double>(IR_TSDF_MAX_Y_PARAM, 0.0);
-  params.nh->declare_parameter<double>(IR_TSDF_MAX_Z_PARAM, 0.0);
-  params.nh->declare_parameter<float>(IR_RGBD_DEPTH_SCALE_PARAM, 1000.0);
-  params.nh->declare_parameter<float>(IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
-  params.nh->declare_parameter<bool>(IR_LIVE_PARAM, true);
-  params.nh->declare_parameter<double>(IR_NORMAL_ANGLE_TOL_PARAM, -1.0);
-  params.nh->declare_parameter<double>(IR_NORMAL_X_PARAM, 0.0);
-  params.nh->declare_parameter<double>(IR_NORMAL_Y_PARAM, 0.0);
-  params.nh->declare_parameter<double>(IR_NORMAL_Z_PARAM, 1.0);
+  // Industrial reconstruction start  
+  try_declare_parameter<std::string>(params.nh, CAMERA_FRAME_PARAM, "");
+  try_declare_parameter<float>(params.nh, IR_TSDF_VOXEL_PARAM, 0.01f);
+  try_declare_parameter<float>(params.nh, IR_TSDF_SDF_PARAM, 0.03f);
+  try_declare_parameter<double>(params.nh, IR_TSDF_MIN_X_PARAM, 0.0);
+  try_declare_parameter<double>(params.nh, IR_TSDF_MIN_Y_PARAM, 0.0);
+  try_declare_parameter<double>(params.nh, IR_TSDF_MIN_Z_PARAM, 0.0);
+  try_declare_parameter<double>(params.nh, IR_TSDF_MAX_X_PARAM, 0.0);
+  try_declare_parameter<double>(params.nh, IR_TSDF_MAX_Y_PARAM, 0.0);
+  try_declare_parameter<double>(params.nh, IR_TSDF_MAX_Z_PARAM, 0.0);
+  try_declare_parameter<float>(params.nh, IR_RGBD_DEPTH_SCALE_PARAM, 1000.0);
+  try_declare_parameter<float>(params.nh, IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
+  try_declare_parameter<bool>(params.nh, IR_LIVE_PARAM, true);
+  try_declare_parameter<double>(params.nh, IR_NORMAL_ANGLE_TOL_PARAM, -1.0);
+  try_declare_parameter<double>(params.nh, IR_NORMAL_X_PARAM, 0.0);
+  try_declare_parameter<double>(params.nh, IR_NORMAL_Y_PARAM, 0.0);
+  try_declare_parameter<double>(params.nh, IR_NORMAL_Z_PARAM, 1.0);
   factory.registerNodeType<snp_application::StartReconstructionServiceNode>("StartReconstructionService", params);
 
   // Industrial reconstruction stop
-  params.nh->declare_parameter<int>(IR_MIN_FACES_PARAM, 0);
-  params.nh->declare_parameter<std::string>(MESH_FILE_PARAM, "");
-  params.nh->declare_parameter<std::string>(IR_ARCHIVE_DIR_PARAM, "");
+  try_declare_parameter<int>(params.nh, IR_MIN_FACES_PARAM, 0);
+  try_declare_parameter<std::string>(params.nh, MESH_FILE_PARAM, "");
+  try_declare_parameter<std::string>(params.nh, IR_ARCHIVE_DIR_PARAM, "");
   factory.registerNodeType<snp_application::StopReconstructionServiceNode>("StopReconstructionService", params);
 }

--- a/snp_application/src/bt/plugins.cpp
+++ b/snp_application/src/bt/plugins.cpp
@@ -8,7 +8,7 @@
 
 #include <behaviortree_cpp/bt_factory.h>
 
-template<typename T>
+template <typename T>
 void try_declare_parameter(rclcpp::Node::SharedPtr node, const std::string& key, const T& value)
 {
   if (!node->has_parameter(key))
@@ -37,8 +37,6 @@ BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory,
   factory.registerNodeType<snp_application::MotionPlanPubNode>("MotionPlanPub", params);
   factory.registerNodeType<snp_application::FollowJointTrajectoryActionNode>("FollowJointTrajectoryAction", params);
   factory.registerNodeType<snp_application::GetCurrentJointStateNode>("GetCurrentJointState", params);
-  factory.registerNodeType<snp_application::GenerateFreespaceMotionPlanServiceNode>(
-      "GenerateFreespaceMotionPlanService", params);
   factory.registerNodeType<snp_application::GenerateScanMotionPlanServiceNode>("GenerateScanMotionPlanService", params);
   factory.registerNodeType<snp_application::GenerateToolPathsServiceNode>("GenerateToolPathsService", params);
 
@@ -53,7 +51,11 @@ BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory,
   try_declare_parameter<std::string>(params.nh, TCP_FRAME_PARAM, "");
   factory.registerNodeType<snp_application::GenerateMotionPlanServiceNode>("GenerateMotionPlanService", params);
 
-  // Industrial reconstruction start  
+  try_declare_parameter<std::string>(params.nh, FREESPACE_MOTION_GROUP_PARAM, "");
+  factory.registerNodeType<snp_application::GenerateFreespaceMotionPlanServiceNode>(
+      "GenerateFreespaceMotionPlanService", params);
+
+  // Industrial reconstruction start
   try_declare_parameter<std::string>(params.nh, CAMERA_FRAME_PARAM, "");
   try_declare_parameter<float>(params.nh, IR_TSDF_VOXEL_PARAM, 0.01f);
   try_declare_parameter<float>(params.nh, IR_TSDF_SDF_PARAM, 0.03f);

--- a/snp_application/src/bt/plugins.cpp
+++ b/snp_application/src/bt/plugins.cpp
@@ -1,0 +1,40 @@
+#include <snp_application/bt/button_approval_node.h>
+#include <snp_application/bt/button_monitor_node.h>
+#include <snp_application/bt/progress_decorator_node.h>
+#include <snp_application/bt/set_page_decorator_node.h>
+#include <snp_application/bt/snp_bt_ros_nodes.h>
+#include <snp_application/bt/snp_sequence_with_memory_node.h>
+
+#include <behaviortree_cpp/bt_factory.h>
+
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<snp_application::ButtonApprovalNode>("ButtonApproval");
+  factory.registerNodeType<snp_application::ButtonMonitorNode>("ButtonMonitor");
+  factory.registerNodeType<snp_application::ProgressDecoratorNode>("Progress");
+  factory.registerNodeType<snp_application::SetPageDecoratorNode>("SetPage");
+  factory.registerNodeType<snp_application::SNPSequenceWithMemory>("SNPSequenceWithMemory");
+  factory.registerNodeType<snp_application::ReverseTrajectoryNode>("ReverseTrajectory");
+  factory.registerNodeType<snp_application::CombineTrajectoriesNode>("CombineTrajectories");
+}
+
+BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory, const BT::RosNodeParams& params)
+{
+  factory.registerNodeType<snp_application::UpdateTrajectoryStartStateNode>("UpdateTrajectoryStartState", params.nh);
+  factory.registerNodeType<snp_application::RosSpinnerNode>("RosSpinner", params.nh);
+
+  factory.registerNodeType<snp_application::TriggerServiceNode>("TriggerService", params);
+  factory.registerNodeType<snp_application::ExecuteMotionPlanServiceNode>("ExecuteMotionPlanService", params);
+  factory.registerNodeType<snp_application::GenerateMotionPlanServiceNode>("GenerateMotionPlanService", params);
+  factory.registerNodeType<snp_application::GenerateFreespaceMotionPlanServiceNode>("GenerateFreespaceMotionPlanServic"
+                                                                                    "e",
+                                                                                    params);
+  factory.registerNodeType<snp_application::GenerateScanMotionPlanServiceNode>("GenerateScanMotionPlanService", params);
+  factory.registerNodeType<snp_application::GenerateToolPathsServiceNode>("GenerateToolPathsService", params);
+  factory.registerNodeType<snp_application::StartReconstructionServiceNode>("StartReconstructionService", params);
+  factory.registerNodeType<snp_application::StopReconstructionServiceNode>("StopReconstructionService", params);
+  factory.registerNodeType<snp_application::ToolPathsPubNode>("ToolPathsPub", params);
+  factory.registerNodeType<snp_application::MotionPlanPubNode>("MotionPlanPub", params);
+  factory.registerNodeType<snp_application::FollowJointTrajectoryActionNode>("FollowJointTrajectoryAction", params);
+  factory.registerNodeType<snp_application::GetCurrentJointStateNode>("GetCurrentJointState", params);
+}

--- a/snp_application/src/bt/plugins.cpp
+++ b/snp_application/src/bt/plugins.cpp
@@ -30,9 +30,8 @@ BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory,
   factory.registerNodeType<snp_application::MotionPlanPubNode>("MotionPlanPub", params);
   factory.registerNodeType<snp_application::FollowJointTrajectoryActionNode>("FollowJointTrajectoryAction", params);
   factory.registerNodeType<snp_application::GetCurrentJointStateNode>("GetCurrentJointState", params);
-  factory.registerNodeType<snp_application::GenerateFreespaceMotionPlanServiceNode>("GenerateFreespaceMotionPlanServic"
-                                                                                    "e",
-                                                                                    params);
+  factory.registerNodeType<snp_application::GenerateFreespaceMotionPlanServiceNode>(
+      "GenerateFreespaceMotionPlanService", params);
   factory.registerNodeType<snp_application::GenerateScanMotionPlanServiceNode>("GenerateScanMotionPlanService", params);
   factory.registerNodeType<snp_application::GenerateToolPathsServiceNode>("GenerateToolPathsService", params);
 

--- a/snp_application/src/bt/plugins.cpp
+++ b/snp_application/src/bt/plugins.cpp
@@ -4,6 +4,7 @@
 #include <snp_application/bt/set_page_decorator_node.h>
 #include <snp_application/bt/snp_bt_ros_nodes.h>
 #include <snp_application/bt/snp_sequence_with_memory_node.h>
+#include <snp_application/bt/utils.h>
 
 #include <behaviortree_cpp/bt_factory.h>
 
@@ -20,21 +21,54 @@ BT_REGISTER_NODES(factory)
 
 BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory, const BT::RosNodeParams& params)
 {
-  factory.registerNodeType<snp_application::UpdateTrajectoryStartStateNode>("UpdateTrajectoryStartState", params.nh);
-  factory.registerNodeType<snp_application::RosSpinnerNode>("RosSpinner", params.nh);
+  using namespace snp_application;
 
+  factory.registerNodeType<snp_application::RosSpinnerNode>("RosSpinner", params.nh);
   factory.registerNodeType<snp_application::TriggerServiceNode>("TriggerService", params);
   factory.registerNodeType<snp_application::ExecuteMotionPlanServiceNode>("ExecuteMotionPlanService", params);
-  factory.registerNodeType<snp_application::GenerateMotionPlanServiceNode>("GenerateMotionPlanService", params);
+  factory.registerNodeType<snp_application::ToolPathsPubNode>("ToolPathsPub", params);
+  factory.registerNodeType<snp_application::MotionPlanPubNode>("MotionPlanPub", params);
+  factory.registerNodeType<snp_application::FollowJointTrajectoryActionNode>("FollowJointTrajectoryAction", params);
+  factory.registerNodeType<snp_application::GetCurrentJointStateNode>("GetCurrentJointState", params);
   factory.registerNodeType<snp_application::GenerateFreespaceMotionPlanServiceNode>("GenerateFreespaceMotionPlanServic"
                                                                                     "e",
                                                                                     params);
   factory.registerNodeType<snp_application::GenerateScanMotionPlanServiceNode>("GenerateScanMotionPlanService", params);
   factory.registerNodeType<snp_application::GenerateToolPathsServiceNode>("GenerateToolPathsService", params);
+
+  // Nodes requiring parameters
+  // Update trajectory start state
+  params.nh->declare_parameter<double>(START_STATE_REPLACEMENT_TOLERANCE_PARAM, 1.0 * M_PI / 180.0);
+  factory.registerNodeType<snp_application::UpdateTrajectoryStartStateNode>("UpdateTrajectoryStartState", params.nh);
+
+  // Motion plan generation
+  params.nh->declare_parameter<std::string>(MOTION_GROUP_PARAM, "");
+  params.nh->declare_parameter<std::string>(REF_FRAME_PARAM, "");
+  params.nh->declare_parameter<std::string>(TCP_FRAME_PARAM, "");
+  factory.registerNodeType<snp_application::GenerateMotionPlanServiceNode>("GenerateMotionPlanService", params);
+
+  // Industrial reconstruction start
+  params.nh->declare_parameter<std::string>(CAMERA_FRAME_PARAM, "");
+  params.nh->declare_parameter<float>(IR_TSDF_VOXEL_PARAM, 0.01f);
+  params.nh->declare_parameter<float>(IR_TSDF_SDF_PARAM, 0.03f);
+  params.nh->declare_parameter<double>(IR_TSDF_MIN_X_PARAM, 0.0);
+  params.nh->declare_parameter<double>(IR_TSDF_MIN_Y_PARAM, 0.0);
+  params.nh->declare_parameter<double>(IR_TSDF_MIN_Z_PARAM, 0.0);
+  params.nh->declare_parameter<double>(IR_TSDF_MAX_X_PARAM, 0.0);
+  params.nh->declare_parameter<double>(IR_TSDF_MAX_Y_PARAM, 0.0);
+  params.nh->declare_parameter<double>(IR_TSDF_MAX_Z_PARAM, 0.0);
+  params.nh->declare_parameter<float>(IR_RGBD_DEPTH_SCALE_PARAM, 1000.0);
+  params.nh->declare_parameter<float>(IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
+  params.nh->declare_parameter<bool>(IR_LIVE_PARAM, true);
+  params.nh->declare_parameter<double>(IR_NORMAL_ANGLE_TOL_PARAM, -1.0);
+  params.nh->declare_parameter<double>(IR_NORMAL_X_PARAM, 0.0);
+  params.nh->declare_parameter<double>(IR_NORMAL_Y_PARAM, 0.0);
+  params.nh->declare_parameter<double>(IR_NORMAL_Z_PARAM, 1.0);
   factory.registerNodeType<snp_application::StartReconstructionServiceNode>("StartReconstructionService", params);
+
+  // Industrial reconstruction stop
+  params.nh->declare_parameter<int>(IR_MIN_FACES_PARAM, 0);
+  params.nh->declare_parameter<std::string>(MESH_FILE_PARAM, "");
+  params.nh->declare_parameter<std::string>(IR_ARCHIVE_DIR_PARAM, "");
   factory.registerNodeType<snp_application::StopReconstructionServiceNode>("StopReconstructionService", params);
-  factory.registerNodeType<snp_application::ToolPathsPubNode>("ToolPathsPub", params);
-  factory.registerNodeType<snp_application::MotionPlanPubNode>("MotionPlanPub", params);
-  factory.registerNodeType<snp_application::FollowJointTrajectoryActionNode>("FollowJointTrajectoryAction", params);
-  factory.registerNodeType<snp_application::GetCurrentJointStateNode>("GetCurrentJointState", params);
 }

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -444,7 +444,7 @@ BT::NodeStatus FollowJointTrajectoryActionNode::onResultReceived(const WrappedRe
 UpdateTrajectoryStartStateNode::UpdateTrajectoryStartStateNode(const std::string& instance_name,
                                                                const BT::NodeConfig& config,
                                                                rclcpp::Node::SharedPtr node)
-  : BT::ActionNodeBase(instance_name, config), node_(node)
+  : BT::SyncActionNode(instance_name, config), node_(node)
 {
 }
 
@@ -528,10 +528,6 @@ BT::NodeStatus UpdateTrajectoryStartStateNode::tick()
   return BT::NodeStatus::SUCCESS;
 }
 
-void UpdateTrajectoryStartStateNode::halt()
-{
-}
-
 /**
  * @details Adapted from
  * https://github.com/a5-robotics/A5/blob/1c1b280970722c6b41d997f91ef50ff1571eeeac/a5_utils/src/trajectories/trajectories.cpp#L77C4-L96
@@ -568,7 +564,7 @@ trajectory_msgs::msg::JointTrajectory reverseTrajectory(const trajectory_msgs::m
 }
 
 ReverseTrajectoryNode::ReverseTrajectoryNode(const std::string& instance_name, const BT::NodeConfig& config)
-  : BT::ActionNodeBase(instance_name, config)
+  : BT::SyncActionNode(instance_name, config)
 {
 }
 
@@ -599,12 +595,8 @@ BT::NodeStatus ReverseTrajectoryNode::tick()
   return BT::NodeStatus::SUCCESS;
 }
 
-void ReverseTrajectoryNode::halt()
-{
-}
-
 CombineTrajectoriesNode::CombineTrajectoriesNode(const std::string& instance_name, const BT::NodeConfig& config)
-  : BT::ActionNodeBase(instance_name, config)
+  : BT::SyncActionNode(instance_name, config)
 {
 }
 
@@ -646,10 +638,6 @@ BT::NodeStatus CombineTrajectoriesNode::tick()
   }
 
   return BT::NodeStatus::SUCCESS;
-}
-
-void CombineTrajectoriesNode::halt()
-{
 }
 
 BT::NodeStatus GetCurrentJointStateNode::onTick(const typename sensor_msgs::msg::JointState::SharedPtr& last_msg)

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -78,7 +78,7 @@ bool GenerateFreespaceMotionPlanServiceNode::setRequest(typename Request::Shared
   request->js1 = snp_application::getBTInput<sensor_msgs::msg::JointState>(this, START_JOINT_STATE_INPUT_PORT_KEY);
   request->js2 = snp_application::getBTInput<sensor_msgs::msg::JointState>(this, GOAL_JOINT_STATE_INPUT_PORT_KEY);
 
-  request->motion_group = get_parameter<std::string>(node_, MOTION_GROUP_PARAM);
+  request->motion_group = get_parameter<std::string>(node_, FREESPACE_MOTION_GROUP_PARAM);
   request->mesh_filename = get_parameter<std::string>(node_, MESH_FILE_PARAM);
   request->mesh_frame = get_parameter<std::string>(node_, REF_FRAME_PARAM);
   request->tcp_frame = get_parameter<std::string>(node_, TCP_FRAME_PARAM);

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -2,32 +2,29 @@
 #include "ui_snp_widget.h"
 // BT
 #include <snp_application/bt/bt_thread.h>
-#include <snp_application/bt/button_approval_node.h>
-#include <snp_application/bt/button_monitor_node.h>
-#include <snp_application/bt/progress_decorator_node.h>
-#include <snp_application/bt/set_page_decorator_node.h>
-#include <snp_application/bt/snp_bt_ros_nodes.h>
-#include <snp_application/bt/snp_sequence_with_memory_node.h>
 #include <snp_application/bt/text_edit_logger.h>
 #include <snp_application/bt/utils.h>
 
 #include <behaviortree_cpp/bt_factory.h>
+#include <behaviortree_ros2/plugins.hpp>
 #include <boost_plugin_loader/plugin_loader.h>
 #include <QMessageBox>
 #include <QTextStream>
 #include <QScrollBar>
 #include <QTextEdit>
 #include <QStackedWidget>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <snp_tpp/tpp_widget.h>
 #include <trajectory_preview/trajectory_preview_widget.h>
 
-static const std::string BT_FILES_PARAM = "bt_files";
-static const std::string BT_PARAM = "tree";
-static const std::string BT_FREESPACE_PARAM = "freespace_tree";
-static const std::string BT_SHORT_TIMEOUT_PARAM = "bt_short_timeout";
-static const std::string BT_LONG_TIMEOUT_PARAM = "bt_long_timeout";
-static const std::string FOLLOW_JOINT_TRAJECTORY_ACTION = "follow_joint_trajectory_action";
-static const std::string HOME_STATE_NAME = "home_state";
+static const char* BT_FILES_PARAM = "bt_files";
+static const char* BT_PLUGIN_LIBS_PARAM = "bt_plugin_libs";
+static const char* BT_ROS_PLUGIN_LIBS_PARAM = "bt_ros_plugin_libs";
+static const char* BT_PARAM = "tree";
+static const char* BT_FREESPACE_PARAM = "freespace_tree";
+static const char* BT_TIMEOUT_PARAM = "bt_timeout";
+static const char* FOLLOW_JOINT_TRAJECTORY_ACTION = "follow_joint_trajectory_action";
+static const char* HOME_STATE_NAME = "home_state";
 
 class TPPDialog : public QDialog
 {
@@ -141,9 +138,10 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   bt_node_->declare_parameter<std::string>(MESH_FILE_PARAM, "");
   bt_node_->declare_parameter<double>(START_STATE_REPLACEMENT_TOLERANCE_PARAM, 1.0 * M_PI / 180.0);
   bt_node_->declare_parameter<std::vector<std::string>>(BT_FILES_PARAM, {});
+  bt_node_->declare_parameter<std::vector<std::string>>(BT_PLUGIN_LIBS_PARAM, {});
+  bt_node_->declare_parameter<std::vector<std::string>>(BT_ROS_PLUGIN_LIBS_PARAM, {});
   bt_node_->declare_parameter<std::string>(BT_PARAM, "");
-  bt_node_->declare_parameter<int>(BT_SHORT_TIMEOUT_PARAM, 5);    // seconds
-  bt_node_->declare_parameter<int>(BT_LONG_TIMEOUT_PARAM, 6000);  // seconds
+  bt_node_->declare_parameter<int>(BT_TIMEOUT_PARAM, 6000);  // seconds
   bt_node_->declare_parameter<std::string>(FOLLOW_JOINT_TRAJECTORY_ACTION, "follow_joint_trajectory");
 
   // Home state
@@ -173,8 +171,8 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   board_->set(ERROR_MESSAGE_KEY, "");
 
   // Populate the blackboard with buttons
-  board_->set(SetPageDecoratorNode::STACKED_WIDGET_KEY, ui_->stacked_widget);
-  board_->set(ProgressDecoratorNode::PROGRESS_BAR_KEY, ui_->progress_bar);
+  board_->set("stacked_widget", ui_->stacked_widget);
+  board_->set("progress_bar", ui_->progress_bar);
   board_->set("reset", static_cast<QAbstractButton*>(ui_->push_button_reset));
   board_->set("halt", static_cast<QAbstractButton*>(ui_->push_button_halt));
 
@@ -186,25 +184,28 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   board_->set("tpp_config", static_cast<QAbstractButton*>(ui_->tool_button_tpp));
 }
 
-BT::BehaviorTreeFactory SNPWidget::createBTFactory(int ros_short_timeout, int ros_long_timeout)
+BT::BehaviorTreeFactory SNPWidget::createBTFactory(int ros_timeout)
 {
   BT::BehaviorTreeFactory bt_factory;
 
-  // Register custom nodes
-  bt_factory.registerNodeType<ButtonMonitorNode>("ButtonMonitor");
-  bt_factory.registerNodeType<ButtonApprovalNode>("ButtonApproval");
-  bt_factory.registerNodeType<ProgressDecoratorNode>("Progress");
-  bt_factory.registerNodeType<SetPageDecoratorNode>("SetPage");
-  bt_factory.registerNodeType<SNPSequenceWithMemory>("SNPSequenceWithMemory");
-  bt_factory.registerNodeType<RosSpinnerNode>("RosSpinner", bt_node_);
-  bt_factory.registerNodeType<ReverseTrajectoryNode>("ReverseTrajectory");
-  bt_factory.registerNodeType<CombineTrajectoriesNode>("CombineTrajectories");
-  bt_factory.registerNodeType<UpdateTrajectoryStartStateNode>("UpdateTrajectoryStartState", bt_node_);
+  // Register non-ROS plugins
+  {
+    auto bt_plugins = get_parameter<std::vector<std::string>>(bt_node_, BT_PLUGIN_LIBS_PARAM);
+    for (const std::string& plugin : bt_plugins)
+      bt_factory.registerFromPlugin(std::filesystem::path(plugin));
+  }
 
-  BT::RosNodeParams ros_params;
-  ros_params.nh = bt_node_;
-  ros_params.wait_for_server_timeout = std::chrono::seconds(0);
-  ros_params.server_timeout = std::chrono::seconds(ros_short_timeout);
+  // Register ROS plugins
+  {
+    BT::RosNodeParams ros_params;
+    ros_params.nh = bt_node_;
+    ros_params.wait_for_server_timeout = std::chrono::seconds(0);
+    ros_params.server_timeout = std::chrono::seconds(ros_timeout);
+
+    auto bt_ros_plugins = get_parameter<std::vector<std::string>>(bt_node_, BT_ROS_PLUGIN_LIBS_PARAM);
+    for (const std::string& plugin : bt_ros_plugins)
+      RegisterRosNode(bt_factory, std::filesystem::path(plugin), ros_params);
+  }
 
   // Get joint trajectory action topic name from parameter and store it in the blackboard
   board_->set(FOLLOW_JOINT_TRAJECTORY_ACTION,
@@ -214,24 +215,6 @@ BT::BehaviorTreeFactory SNPWidget::createBTFactory(int ros_short_timeout, int ro
   home_state.name = snp_application::get_parameter<std::vector<std::string>>(bt_node_, HOME_STATE_JOINT_NAMES_PARAM);
   home_state.position = snp_application::get_parameter<std::vector<double>>(bt_node_, HOME_STATE_JOINT_VALUES_PARAM);
   board_->set(HOME_STATE_NAME, home_state);
-
-  // Publishers/Subscribers
-  bt_factory.registerNodeType<ToolPathsPubNode>("ToolPathsPub", ros_params);
-  bt_factory.registerNodeType<MotionPlanPubNode>("MotionPlanPub", ros_params);
-  bt_factory.registerNodeType<GetCurrentJointStateNode>("GetCurrentJointState", ros_params);
-  // Short-running services
-  bt_factory.registerNodeType<TriggerServiceNode>("TriggerService", ros_params);
-  bt_factory.registerNodeType<GenerateToolPathsServiceNode>("GenerateToolPathsService", ros_params);
-  bt_factory.registerNodeType<StartReconstructionServiceNode>("StartReconstructionService", ros_params);
-  bt_factory.registerNodeType<StopReconstructionServiceNode>("StopReconstructionService", ros_params);
-
-  // Long-running services/actions
-  ros_params.server_timeout = std::chrono::seconds(ros_long_timeout);
-  bt_factory.registerNodeType<ExecuteMotionPlanServiceNode>("ExecuteMotionPlanService", ros_params);
-  bt_factory.registerNodeType<GenerateMotionPlanServiceNode>("GenerateMotionPlanService", ros_params);
-  bt_factory.registerNodeType<GenerateFreespaceMotionPlanServiceNode>("GenerateFreespaceMotionPlanService", ros_params);
-  bt_factory.registerNodeType<GenerateScanMotionPlanServiceNode>("GenerateScanMotionPlanService", ros_params);
-  bt_factory.registerNodeType<FollowJointTrajectoryActionNode>("FollowJointTrajectoryAction", ros_params);
 
   return bt_factory;
 }
@@ -243,12 +226,11 @@ void SNPWidget::runTreeWithThread(const std::string& bt_tree_name)
     auto* thread = new BTThread(this);
 
     // Create the BT factory
-    BT::BehaviorTreeFactory bt_factory = createBTFactory(get_parameter<int>(bt_node_, BT_SHORT_TIMEOUT_PARAM),
-                                                         get_parameter<int>(bt_node_, BT_LONG_TIMEOUT_PARAM));
+    BT::BehaviorTreeFactory bt_factory = createBTFactory(get_parameter<int>(bt_node_, BT_TIMEOUT_PARAM));
 
     auto bt_files = get_parameter<std::vector<std::string>>(bt_node_, BT_FILES_PARAM);
     if (bt_files.empty())
-      throw std::runtime_error("Parameter '" + BT_FILES_PARAM + "' is empty");
+      throw std::runtime_error("Parameter '" + std::string(BT_FILES_PARAM) + "' is empty");
 
     for (const std::string& file : bt_files)
       bt_factory.registerBehaviorTreeFromFile(file);

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -131,12 +131,6 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   });
 
   // Declare parameters
-  bt_node_->declare_parameter<std::string>(MOTION_GROUP_PARAM, "");
-  bt_node_->declare_parameter<std::string>(REF_FRAME_PARAM, "");
-  bt_node_->declare_parameter<std::string>(TCP_FRAME_PARAM, "");
-  bt_node_->declare_parameter<std::string>(CAMERA_FRAME_PARAM, "");
-  bt_node_->declare_parameter<std::string>(MESH_FILE_PARAM, "");
-  bt_node_->declare_parameter<double>(START_STATE_REPLACEMENT_TOLERANCE_PARAM, 1.0 * M_PI / 180.0);
   bt_node_->declare_parameter<std::vector<std::string>>(BT_FILES_PARAM, {});
   bt_node_->declare_parameter<std::vector<std::string>>(BT_PLUGIN_LIBS_PARAM, {});
   bt_node_->declare_parameter<std::vector<std::string>>(BT_ROS_PLUGIN_LIBS_PARAM, {});
@@ -148,24 +142,6 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   bt_node_->declare_parameter<std::string>(BT_FREESPACE_PARAM, "");
   bt_node_->declare_parameter<std::vector<double>>(HOME_STATE_JOINT_VALUES_PARAM, {});
   bt_node_->declare_parameter<std::vector<std::string>>(HOME_STATE_JOINT_NAMES_PARAM, {});
-
-  bt_node_->declare_parameter<float>(IR_TSDF_VOXEL_PARAM, 0.01f);
-  bt_node_->declare_parameter<float>(IR_TSDF_SDF_PARAM, 0.03f);
-  bt_node_->declare_parameter<double>(IR_TSDF_MIN_X_PARAM, 0.0);
-  bt_node_->declare_parameter<double>(IR_TSDF_MIN_Y_PARAM, 0.0);
-  bt_node_->declare_parameter<double>(IR_TSDF_MIN_Z_PARAM, 0.0);
-  bt_node_->declare_parameter<double>(IR_TSDF_MAX_X_PARAM, 0.0);
-  bt_node_->declare_parameter<double>(IR_TSDF_MAX_Y_PARAM, 0.0);
-  bt_node_->declare_parameter<double>(IR_TSDF_MAX_Z_PARAM, 0.0);
-  bt_node_->declare_parameter<float>(IR_RGBD_DEPTH_SCALE_PARAM, 1000.0);
-  bt_node_->declare_parameter<float>(IR_RGBD_DEPTH_TRUNC_PARAM, 1.1f);
-  bt_node_->declare_parameter<bool>(IR_LIVE_PARAM, true);
-  bt_node_->declare_parameter<int>(IR_MIN_FACES_PARAM, 0);
-  bt_node_->declare_parameter<double>(IR_NORMAL_ANGLE_TOL_PARAM, -1.0);
-  bt_node_->declare_parameter<double>(IR_NORMAL_X_PARAM, 0.0);
-  bt_node_->declare_parameter<double>(IR_NORMAL_Y_PARAM, 0.0);
-  bt_node_->declare_parameter<double>(IR_NORMAL_Z_PARAM, 1.0);
-  bt_node_->declare_parameter<std::string>(IR_ARCHIVE_DIR_PARAM, "");
 
   // Set the error message key in the blackboard
   board_->set(ERROR_MESSAGE_KEY, "");


### PR DESCRIPTION
This PR:
- Updates some custom BT nodes to `SyncActionNode` type to address #125 
- Exports a library of Behavior Tree plugins for better modularity when building applications on top of this repo
- Updates the SNP widget to load behavior tree plugins from parameter. This should hopefully remove the need to override the SNP widget in other projects (e.g., `snp_automate_2022/3, etc.)