### PR TITLE
Updated version of industrial reconstruction

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -9,7 +9,7 @@
 - git:
     local-name: industrial_reconstruction
     uri: https://github.com/ros-industrial/industrial_reconstruction.git
-    version: 8fb1006a9fd464a201fe575a742b4a7ee2b31b9c
+    version: dbe6b476ca7c20a23cac118506b40868209fbd9a
 - git:
     local-name: rviz_polygon_selection_tool
     uri: https://github.com/swri-robotics/rviz_polygon_selection_tool.git

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -9,7 +9,7 @@
 - git:
     local-name: industrial_reconstruction
     uri: https://github.com/ros-industrial/industrial_reconstruction.git
-    version: 6e1eadada1f86b716a6fcef0ae5ffb291f9b5e66
+    version: 8fb1006a9fd464a201fe575a742b4a7ee2b31b9c
 - git:
     local-name: rviz_polygon_selection_tool
     uri: https://github.com/swri-robotics/rviz_polygon_selection_tool.git


### PR DESCRIPTION
Updated to version of `industrial_reconstruction` that does not use `pip` to install `open3d`, preventing downstream issues described [here](https://github.com/ros-industrial/industrial_reconstruction/pull/16)