### PR TITLE
Install open3d dependency via apt

### DIFF
--- a/snp_scanning/package.xml
+++ b/snp_scanning/package.xml
@@ -11,7 +11,7 @@
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
-  <exec_depend>python3-open3d-pip</exec_depend>
+  <exec_depend>python3-open3d</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Builds on #134 to install `open3d` via `apt` instead of `pip`