### PR TITLE
Add drawn toolpath planner

### DIFF
--- a/snp_tpp/CMakeLists.txt
+++ b/snp_tpp/CMakeLists.txt
@@ -28,10 +28,10 @@ find_package(rviz_polygon_selection_tool REQUIRED)
 find_package(snp_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
 
-# Custom mesh modifier
+# Custom mesh modifier and snp planner
 qt5_wrap_ui(${PROJECT_NAME}_ui_mocs ui/roi_selection_mesh_modifier_widget.ui ui/snp_raster_planner_widget.ui)
 qt5_wrap_cpp(${PROJECT_NAME}_mocs include/${PROJECT_NAME}/roi_selection_mesh_modifier_widget.h
-             include/${PROJECT_NAME}/snp_raster_planner_widget.h)
+  include/${PROJECT_NAME}/snp_raster_planner_widget.h)
 add_library(
   ${PROJECT_NAME}_mesh_modifier SHARED
   src/roi_selection_mesh_modifier.cpp
@@ -51,9 +51,30 @@ ament_target_dependencies(
   snp_msgs
   tf2_eigen)
 
+# Custom drawn planner
+qt5_wrap_ui(${PROJECT_NAME}_ui_drawn_mocs ui/drawn_toolpath_planner_widget.ui)
+qt5_wrap_cpp(${PROJECT_NAME}_drawn_mocs include/${PROJECT_NAME}/drawn_toolpath_planner_widget.h)
+add_library(
+  ${PROJECT_NAME}_drawn_toolpath_planner SHARED
+  src/drawn_toolpath_planner.cpp
+  src/drawn_toolpath_planner_widget.cpp
+  ${${PROJECT_NAME}_ui_drawn_mocs}
+  ${${PROJECT_NAME}_drawn_mocs})
+target_include_directories(
+  ${PROJECT_NAME}_drawn_toolpath_planner PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                       "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>" "$<INSTALL_INTERFACE:include>")
+target_link_libraries(${PROJECT_NAME}_drawn_toolpath_planner noether::noether_tpp noether::noether_gui)
+ament_target_dependencies(
+  ${PROJECT_NAME}_drawn_toolpath_planner
+  geometry_msgs
+  rviz_polygon_selection_tool
+  rclcpp
+  snp_msgs
+  tf2_eigen)
+
 # Noether plugin library
 add_library(${PROJECT_NAME}_plugins SHARED src/plugins.cpp)
-target_link_libraries(${PROJECT_NAME}_plugins ${PROJECT_NAME}_mesh_modifier)
+target_link_libraries(${PROJECT_NAME}_plugins ${PROJECT_NAME}_mesh_modifier ${PROJECT_NAME}_drawn_toolpath_planner)
 
 # Custom TPP widget
 qt5_wrap_cpp(${PROJECT_NAME}_widget_mocs include/${PROJECT_NAME}/tpp_widget.h)
@@ -77,7 +98,7 @@ install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 install(TARGETS ${PROJECT_NAME}_app DESTINATION lib/${PROJECT_NAME})
 
 # Install the library(ies)
-install(TARGETS ${PROJECT_NAME}_mesh_modifier ${PROJECT_NAME}_plugins ${PROJECT_NAME}_widget
+install(TARGETS ${PROJECT_NAME}_mesh_modifier ${PROJECT_NAME}_drawn_toolpath_planner ${PROJECT_NAME}_plugins ${PROJECT_NAME}_widget
         EXPORT ${PROJECT_NAME}-targets DESTINATION lib)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(

--- a/snp_tpp/include/snp_tpp/drawn_toolpath_planner.h
+++ b/snp_tpp/include/snp_tpp/drawn_toolpath_planner.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <vector>
+#include <geometry_msgs/msg/polygon_stamped.hpp>
+#include <pcl/PolygonMesh.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <noether_tpp/tool_path_planners/raster/raster_planner.h>
+
+namespace snp_tpp
+{
+class DrawnToolpathPlanner : public noether::ToolPathPlanner
+{
+public:
+  DrawnToolpathPlanner(rclcpp::Node::SharedPtr node, std::vector<geometry_msgs::msg::PolygonStamped> boundaries);
+
+  noether::ToolPaths plan(const pcl::PolygonMesh& mesh) const override final;
+
+  void setPointSpacing(const double point_spacing);
+  void setMinSegmentSize(const double min_segment_size);
+  void setSearchRadius(const double search_radius);
+
+protected:
+  /** @brief Distance between waypoints on the same raster line (m) */
+  double point_spacing_;
+  /** @brief Minimum length of a segment to generate waypoints on (m) */
+  double min_segment_size_;
+  /** @brief Search radius around a point to calculate normal (m) */
+  double search_radius_;
+
+  std::vector<geometry_msgs::msg::PolygonStamped> boundaries_;
+  tf2_ros::Buffer buffer_;
+  tf2_ros::TransformListener listener_;
+};
+
+}  // namespace snp_tpp

--- a/snp_tpp/include/snp_tpp/drawn_toolpath_planner_widget.h
+++ b/snp_tpp/include/snp_tpp/drawn_toolpath_planner_widget.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <snp_tpp/drawn_toolpath_planner.h>
+
+#include <noether_gui/widgets.h>
+
+#include <QWidget>
+#include <rclcpp/client.hpp>
+#include <rclcpp/executors/single_threaded_executor.hpp>
+#include <rclcpp/node.hpp>
+#include <rviz_polygon_selection_tool/srv/get_selection.hpp>
+
+namespace Ui
+{
+class DrawnToolpathPlanner;
+}
+
+namespace snp_tpp
+{
+class DrawnToolpathPlannerWidget : public noether::ToolPathPlannerWidget
+{
+  Q_OBJECT
+public:
+  DrawnToolpathPlannerWidget(QWidget* parent = nullptr);
+  virtual ~DrawnToolpathPlannerWidget();
+
+  noether::ToolPathPlanner::ConstPtr create() const override;
+
+  void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
+
+private:
+  void spin();
+
+  Ui::DrawnToolpathPlanner* ui_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Client<rviz_polygon_selection_tool::srv::GetSelection>::SharedPtr client_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
+  std::thread thread_;
+};
+
+}  // namespace snp_tpp

--- a/snp_tpp/src/drawn_toolpath_planner.cpp
+++ b/snp_tpp/src/drawn_toolpath_planner.cpp
@@ -1,0 +1,218 @@
+#include <snp_tpp/drawn_toolpath_planner.h>
+
+#include <noether_tpp/tool_path_planners/raster/raster_utils.h>
+
+#include <pcl/conversions.h>
+#include <pcl/common/pca.h>
+#include <pcl/io/vtk_lib_io.h>
+
+#include <vtkPlane.h>
+#include <vtkCutter.h>
+#include <vtkStripper.h>
+#include <vtkAppendPolyData.h>
+#include <vtkKdTreePointLocator.h>
+#include <vtkCellLocator.h>
+#include <vtkPolyDataNormals.h>
+#include <vtkSmartPointer.h>
+#include <vtkPointData.h>
+#include <vtkMath.h>
+#include <vtkErrorCode.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkCellArray.h>
+
+#include <Eigen/Geometry>
+
+#include <tf2_eigen/tf2_eigen.h>
+
+double computeLength(vtkPoints* points)
+{
+  double total_length = 0.0;
+  vtkIdType num_points = points->GetNumberOfPoints();
+
+  if (num_points < 2)
+  {
+    return total_length;  // No length to compute if less than 2 points
+  }
+
+  for (vtkIdType i = 0; i < num_points - 1; ++i)
+  {
+    double p0[3], p1[3];
+    points->GetPoint(i, p0);
+    points->GetPoint(i + 1, p1);
+
+    double segment_length = std::sqrt(vtkMath::Distance2BetweenPoints(p0, p1));
+    total_length += segment_length;
+  }
+
+  return total_length;
+}
+
+namespace snp_tpp
+{
+
+DrawnToolpathPlanner::DrawnToolpathPlanner(rclcpp::Node::SharedPtr node,
+                                           std::vector<geometry_msgs::msg::PolygonStamped> boundaries)
+  : boundaries_(std::move(boundaries)), buffer_(node->get_clock()), listener_(buffer_)
+{
+}
+
+void DrawnToolpathPlanner::setPointSpacing(const double point_spacing)
+{
+  point_spacing_ = point_spacing;
+}
+void DrawnToolpathPlanner::setMinSegmentSize(const double min_segment_size)
+{
+  min_segment_size_ = min_segment_size;
+}
+void DrawnToolpathPlanner::setSearchRadius(const double search_radius)
+{
+  search_radius_ = search_radius;
+}
+
+noether::ToolPaths DrawnToolpathPlanner::plan(const pcl::PolygonMesh& mesh) const
+{
+  // Convert mesh to VTK format
+  vtkSmartPointer<vtkPolyData> mesh_data = noether::convertMeshToVTKPolyData(mesh);
+
+  // Build locators
+  vtkSmartPointer<vtkKdTreePointLocator> kd_tree = vtkSmartPointer<vtkKdTreePointLocator>::New();
+  kd_tree->SetDataSet(mesh_data);
+  kd_tree->BuildLocator();
+  vtkSmartPointer<vtkCellLocator> cell_locator = vtkSmartPointer<vtkCellLocator>::New();
+  cell_locator->SetDataSet(mesh_data);
+  cell_locator->BuildLocator();
+
+  noether::ToolPaths tool_paths;
+
+  // Iterate over each polygon for each raster
+  for (const auto& polygon : boundaries_)
+  {
+    // Need at least two points
+    if (polygon.polygon.points.size() < 2)
+      continue;
+
+    // Transform polygon points to mesh frame
+    Eigen::Isometry3d transform;
+    try
+    {
+      geometry_msgs::msg::TransformStamped tf = buffer_.lookupTransform(mesh.header.frame_id, polygon.header.frame_id,
+                                                                        tf2::TimePointZero, tf2::durationFromSec(3.0));
+      transform = tf2::transformToEigen(tf.transform);
+    }
+    catch (tf2::TransformException& ex)
+    {
+      RCLCPP_WARN(rclcpp::get_logger("DrawnToolpathPlanner"), "Could not transform polygon: %s", ex.what());
+      continue;
+    }
+
+    // Convert polygon points to Eigen vectors
+    std::vector<Eigen::Vector3d> transformed_points;
+    for (const auto& pt : polygon.polygon.points)
+    {
+      Eigen::Vector3d v(pt.x, pt.y, pt.z);
+      transformed_points.push_back(transform * v);
+    }
+
+    // Generate waypoints along the polygon edges with cumulative length consideration
+    vtkSmartPointer<vtkPoints> waypoints = vtkSmartPointer<vtkPoints>::New();
+    double cumulative_distance = 0.0;
+    double next_distance = 0.0;
+
+    // Add first waypoint
+    waypoints->InsertNextPoint(transformed_points.front().data());
+
+    // Add waypoints along polygon edges, tracking total distance traveled
+    for (size_t i = 0; i < transformed_points.size() - 1; ++i)
+    {
+      const Eigen::Vector3d& p0 = transformed_points[i];
+      const Eigen::Vector3d& p1 = transformed_points[(i + 1)];
+      Eigen::Vector3d direction = p1 - p0;
+      double segment_length = direction.norm();
+      direction.normalize();
+
+      double segment_end_distance = cumulative_distance + segment_length;
+
+      while (next_distance + point_spacing_ <= segment_end_distance)
+      {
+        next_distance += point_spacing_;
+        double t = (next_distance - cumulative_distance) / segment_length;
+        Eigen::Vector3d point = p0 + t * (p1 - p0);
+        waypoints->InsertNextPoint(point.data());
+      }
+
+      cumulative_distance = segment_end_distance;
+    }
+
+    // Check segment length
+    double line_length = computeLength(waypoints);
+    if (line_length < min_segment_size_)
+      continue;
+
+    // Project waypoints onto the mesh
+    vtkSmartPointer<vtkPoints> projected_points = vtkSmartPointer<vtkPoints>::New();
+    for (vtkIdType i = 0; i < waypoints->GetNumberOfPoints(); ++i)
+    {
+      double wp[3];
+      waypoints->GetPoint(i, wp);
+      double closest_point[3];
+      double dist2;
+      vtkIdType cell_id;
+      int sub_id;
+      cell_locator->FindClosestPoint(wp, closest_point, cell_id, sub_id, dist2);
+      projected_points->InsertNextPoint(closest_point);
+    }
+
+    // Create segment data
+    vtkSmartPointer<vtkPolyData> segment_data = vtkSmartPointer<vtkPolyData>::New();
+    segment_data->SetPoints(projected_points);
+
+    // Insert normals
+    if (!noether::insertNormals(search_radius_, mesh_data, kd_tree, segment_data))
+    {
+      throw std::runtime_error("Could not insert normals for polygon raster");
+    }
+
+    // Convert to tool path
+    noether::ToolPathSegment tool_path_segment;
+    for (vtkIdType i = 0; i < segment_data->GetNumberOfPoints(); ++i)
+    {
+      double p[3];
+      segment_data->GetPoint(i, p);
+      double n[3];
+      segment_data->GetPointData()->GetNormals()->GetTuple(i, n);
+
+      Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+      pose.translation() = Eigen::Vector3d(p[0], p[1], p[2]);
+
+      // Compute orientation from normal
+      Eigen::Vector3d normal(n[0], n[1], n[2]);
+      normal.normalize();
+
+      // Define a reference direction for the tool orientation
+      Eigen::Vector3d ref_direction(1.0, 0.0, 0.0);
+      if (std::abs(normal.dot(ref_direction)) > 0.99)
+      {
+        ref_direction = Eigen::Vector3d(0.0, 1.0, 0.0);
+      }
+
+      Eigen::Vector3d x_direction = ref_direction.cross(normal).normalized();
+      Eigen::Vector3d y_direction = normal.cross(x_direction).normalized();
+
+      pose.linear().col(0) = x_direction;
+      pose.linear().col(1) = y_direction;
+      pose.linear().col(2) = normal;
+
+      tool_path_segment.push_back(pose);
+    }
+
+    // Add the segment to a tool path and then to tool paths
+    noether::ToolPath tool_path;
+    tool_path.push_back(tool_path_segment);
+    tool_paths.push_back(tool_path);
+  }
+
+  return tool_paths;
+}
+
+}  // namespace snp_tpp

--- a/snp_tpp/src/drawn_toolpath_planner_widget.cpp
+++ b/snp_tpp/src/drawn_toolpath_planner_widget.cpp
@@ -1,0 +1,75 @@
+#include <snp_tpp/drawn_toolpath_planner_widget.h>
+#include "ui_drawn_toolpath_planner_widget.h"
+
+#include <noether_gui/utils.h>
+#include <yaml-cpp/yaml.h>
+
+namespace snp_tpp
+{
+DrawnToolpathPlannerWidget::DrawnToolpathPlannerWidget(QWidget* parent)
+  : noether::ToolPathPlannerWidget(parent)
+  , ui_(new Ui::DrawnToolpathPlanner())
+  , node_(std::make_shared<rclcpp::Node>("roi_selection_mesh_modifier"))
+  , client_(node_->create_client<rviz_polygon_selection_tool::srv::GetSelection>("get_selection"))
+  , thread_(std::bind(&DrawnToolpathPlannerWidget::spin, this))
+{
+  ui_->setupUi(this);
+}
+
+DrawnToolpathPlannerWidget::~DrawnToolpathPlannerWidget()
+{
+  executor_.cancel();
+  thread_.join();
+}
+
+void DrawnToolpathPlannerWidget::spin()
+{
+  executor_.add_node(node_);
+  executor_.spin();
+}
+
+void DrawnToolpathPlannerWidget::configure(const YAML::Node& config)
+{
+  ui_->double_spin_box_point_spacing->setValue(noether::getEntry<double>(config, "point_spacing"));
+  ui_->double_spin_box_min_seg_length->setValue(noether::getEntry<double>(config, "min_segment_length"));
+  ui_->double_spin_box_normal_radius->setValue(noether::getEntry<double>(config, "normal_radius"));
+}
+
+void DrawnToolpathPlannerWidget::save(YAML::Node& config) const
+{
+  config["point_spacing"] = ui_->double_spin_box_point_spacing->value();
+  config["min_segment_length"] = ui_->double_spin_box_min_seg_length->value();
+  config["normal_radius"] = ui_->double_spin_box_normal_radius->value();
+}
+
+noether::ToolPathPlanner::ConstPtr DrawnToolpathPlannerWidget::create() const
+{
+  if (!client_->service_is_ready())
+    throw std::runtime_error("Drawn toolpath selection service is not available");
+
+  auto request = std::make_shared<rviz_polygon_selection_tool::srv::GetSelection::Request>();
+  auto future = client_->async_send_request(request);
+  switch (future.wait_for(std::chrono::seconds(3)))
+  {
+    case std::future_status::ready:
+      break;
+    case std::future_status::timeout:
+      throw std::runtime_error("Drawn toolpath selection service call to '" + std::string(client_->get_service_name()) +
+                               "' timed out");
+    default:
+      throw std::runtime_error("Drawn toolpath selection service call to '" + std::string(client_->get_service_name()) +
+                               "' failed");
+  }
+
+  rviz_polygon_selection_tool::srv::GetSelection::Response::SharedPtr response = future.get();
+
+  auto planner = std::make_unique<DrawnToolpathPlanner>(node_, response->selection);
+
+  planner->setPointSpacing(ui_->double_spin_box_point_spacing->value());
+  planner->setMinSegmentSize(ui_->double_spin_box_min_seg_length->value());
+  planner->setSearchRadius(ui_->double_spin_box_normal_radius->value());
+
+  return planner;
+}
+
+}  // namespace snp_tpp

--- a/snp_tpp/src/plugins.cpp
+++ b/snp_tpp/src/plugins.cpp
@@ -1,8 +1,9 @@
 #include <snp_tpp/roi_selection_mesh_modifier_widget.h>
+#include <snp_tpp/snp_raster_planner_widget.h>
+#include <snp_tpp/drawn_toolpath_planner_widget.h>
 
 #include <noether_gui/plugin_interface.h>
 #include <yaml-cpp/yaml.h>
-#include <snp_tpp/snp_raster_planner_widget.h>
 #include <noether_gui/widgets/tool_path_planners/raster/raster_planner_widget.h>
 
 namespace snp_tpp
@@ -36,7 +37,22 @@ struct SNPRasterPlannerWidgetPlugin : public noether::ToolPathPlannerWidgetPlugi
   }
 };
 
+struct DrawnToolpathPlannerWidgetPlugin : public noether::ToolPathPlannerWidgetPlugin
+{
+  QWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
+  {
+    auto widget = new DrawnToolpathPlannerWidget(parent);
+
+    // Attempt to configure the widget
+    if (!config.IsNull())
+      widget->configure(config);
+
+    return widget;
+  }
+};
+
 }  // namespace snp_tpp
 
 EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(snp_tpp::ROISelectionMeshModifierWidgetPlugin, ROISelectionMeshModifier)
 EXPORT_TPP_WIDGET_PLUGIN(snp_tpp::SNPRasterPlannerWidgetPlugin, SNPRasterPlanner)
+EXPORT_TPP_WIDGET_PLUGIN(snp_tpp::DrawnToolpathPlannerWidgetPlugin, DrawnToolpathPlanner)

--- a/snp_tpp/ui/drawn_toolpath_planner_widget.ui
+++ b/snp_tpp/ui/drawn_toolpath_planner_widget.ui
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DrawnToolpathPlanner</class>
+ <widget class="QWidget" name="DrawnToolpathPlanner">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>413</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Drawn Toolpath Planner</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <widget class="QGroupBox" name="group_box_drawn_toolpath_planner">
+     <property name="title">
+      <string>Drawn Toolpath Planner</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QFormLayout" name="form_layout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_point_spacing">
+          <property name="text">
+           <string>Point Spacing (m)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QDoubleSpinBox" name="double_spin_box_point_spacing">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.005000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.025000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_min_seg_length">
+          <property name="text">
+           <string>Minimum Segment Length (m)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QDoubleSpinBox" name="double_spin_box_min_seg_length">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.100000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_normal_radius">
+          <property name="text">
+           <string>Normal Radius (m)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QDoubleSpinBox" name="double_spin_box_normal_radius">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.030000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Enables users to use the Polygon Selection Tool to draw multiple rasters for motion planning. This requires the changes to Noether found [here](https://github.com/ros-industrial/noether/pull/262)
![image](https://github.com/user-attachments/assets/60a700e4-ad8f-4df1-aadf-8861470fbeb5)

![Screenshot from 2024-09-24 07-32-24](https://github.com/user-attachments/assets/91648f62-fb61-4b8e-8622-e2ac2024597f)
