### PR TITLE
Add parameter callback when config_file changed

### DIFF
--- a/snp_tpp/include/snp_tpp/tpp_widget.h
+++ b/snp_tpp/include/snp_tpp/tpp_widget.h
@@ -4,6 +4,8 @@
 #include <rclcpp/node.hpp>
 #include <rclcpp/service.hpp>
 #include <snp_msgs/srv/generate_tool_paths.hpp>
+#include <rcl_interfaces/msg/set_parameters_result.hpp>
+#include <rclcpp/parameter_client.hpp>
 
 namespace noether
 {
@@ -25,11 +27,16 @@ public:
   TPPWidget(rclcpp::Node::SharedPtr node, boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
 
 private:
+
+  rcl_interfaces::msg::SetParametersResult parametersCallback(const std::vector<rclcpp::Parameter>& parameters);
+
   void callback(const snp_msgs::srv::GenerateToolPaths::Request::SharedPtr req,
                 const snp_msgs::srv::GenerateToolPaths::Response::SharedPtr res);
 
   noether::ConfigurableTPPPipelineWidget* pipeline_widget_{ nullptr };
   rclcpp::Service<snp_msgs::srv::GenerateToolPaths>::SharedPtr server_{ nullptr };
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
+
 };
 
 }  // namespace snp_tpp

--- a/snp_tpp/include/snp_tpp/tpp_widget.h
+++ b/snp_tpp/include/snp_tpp/tpp_widget.h
@@ -27,7 +27,6 @@ public:
   TPPWidget(rclcpp::Node::SharedPtr node, boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
 
 private:
-
   rcl_interfaces::msg::SetParametersResult parametersCallback(const std::vector<rclcpp::Parameter>& parameters);
 
   void callback(const snp_msgs::srv::GenerateToolPaths::Request::SharedPtr req,
@@ -36,7 +35,6 @@ private:
   noether::ConfigurableTPPPipelineWidget* pipeline_widget_{ nullptr };
   rclcpp::Service<snp_msgs::srv::GenerateToolPaths>::SharedPtr server_{ nullptr };
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_;
-
 };
 
 }  // namespace snp_tpp

--- a/snp_tpp/src/tpp_widget.cpp
+++ b/snp_tpp/src/tpp_widget.cpp
@@ -88,10 +88,33 @@ TPPWidget::TPPWidget(rclcpp::Node::SharedPtr node, boost_plugin_loader::PluginLo
   if (!config_file.empty())
     pipeline_widget_->configure(QString::fromStdString(config_file));
 
+  param_callback_ =
+      node->add_on_set_parameters_callback(std::bind(&TPPWidget::parametersCallback, this, std::placeholders::_1));
+
   connect(load_action, &QAction::triggered, pipeline_widget_,
           &noether::ConfigurableTPPPipelineWidget::onLoadConfiguration);
   connect(save_action, &QAction::triggered, pipeline_widget_,
           &noether::ConfigurableTPPPipelineWidget::onSaveConfiguration);
+}
+
+rcl_interfaces::msg::SetParametersResult TPPWidget::parametersCallback(const std::vector<rclcpp::Parameter>& parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+
+  for (const auto& param : parameters)
+  {
+    if (param.get_name() == "config_file")
+    {
+      const std::string config_file = param.as_string();
+      if (!config_file.empty())
+      {
+        pipeline_widget_->configure(QString::fromStdString(config_file));
+      }
+    }
+  }
+
+  return result;
 }
 
 void TPPWidget::callback(const snp_msgs::srv::GenerateToolPaths::Request::SharedPtr req,


### PR DESCRIPTION
This will allow users to update the parameter of the `config_file` filepath and get that new config applied to the TPP settings.