### PR TITLE
Updating Noether dependencies

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -5,7 +5,7 @@
 - git:
     local-name: noether
     uri: https://github.com/ros-industrial/noether.git
-    version: 882a4b9a3d7b2b9384299fcb263259b8565ccfbc
+    version: 368aed57b3a5f68d334e489c17db415bf0662a40
 - git:
     local-name: industrial_reconstruction
     uri: https://github.com/ros-industrial/industrial_reconstruction.git


### PR DESCRIPTION
This commit of Noether includes [Noether PR #263-279](https://github.com/ros-industrial/noether/pulls?q=is%3Apr+is%3Aclosed)