### PR TITLE
Updated BT to prevent rescan after tpp failure

### DIFF
--- a/snp_application/config/snp.xml
+++ b/snp_application/config/snp.xml
@@ -128,7 +128,7 @@
       </Progress>
       <Progress start="20"
                 end="40">
-        <Sequence>
+        <Sequence _skipIf="skip_scan">
           <SetPage index="3">
             <ButtonApproval name="Approve Scan Execution"
                             approve_button="execute"
@@ -149,11 +149,13 @@
             <ButtonApproval name="Approve Tool Path Plan"
                             approve_button="tpp"
                             disapprove_button="back"
-                            _description="Press next to create a tool path plan"/>
+                            _description="Press next to create a tool path plan"
+                            _onFailure="skip_scan=false&#10;"/>
           </SetPage>
           <GenerateToolPathsService name="Generate Tool Paths"
                                     service_name="generate_tool_paths"
-                                    tool_paths="{tool_paths}"/>
+                                    tool_paths="{tool_paths}"
+                                    _onFailure="skip_scan=true&#10;"/>
           <ToolPathsPub name="Publish Tool Paths"
                         topic_name="tool_paths"
                         tool_paths="{tool_paths}"/>

--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -158,6 +158,7 @@ SNPWidget::SNPWidget(rclcpp::Node::SharedPtr rviz_node, QWidget* parent)
   board_->set("plan", static_cast<QAbstractButton*>(ui_->push_button_motion_plan));
   board_->set("execute", static_cast<QAbstractButton*>(ui_->push_button_motion_execution));
   board_->set("tpp_config", static_cast<QAbstractButton*>(ui_->tool_button_tpp));
+  board_->set("skip_scan", false);
 }
 
 BT::BehaviorTreeFactory SNPWidget::createBTFactory(int ros_timeout)


### PR DESCRIPTION
Using behavior tree pre/post conditions to prevent rescanning directly after a failed tool path generation. 

Pre/post conditions shown in blue below. 
![Screenshot from 2025-02-25 10-29-02](https://github.com/user-attachments/assets/07c5bfce-a415-44af-bf24-62f0575b09a4)
