### PR TITLE
Added convex hull decomposition method for scan mesh addition to environment

### DIFF
--- a/snp_motion_planning/CMakeLists.txt
+++ b/snp_motion_planning/CMakeLists.txt
@@ -23,6 +23,7 @@ endforeach()
 
 find_package(descartes_light REQUIRED)
 find_package(tesseract_command_language REQUIRED)
+find_package(tesseract_collision REQUIRED COMPONENTS vhacd)
 find_package(tesseract_task_composer REQUIRED)
 find_package(tesseract_kinematics REQUIRED)
 find_package(LAPACK REQUIRED) # Requried for ikfast
@@ -55,6 +56,7 @@ target_link_libraries(
   ${PROJECT_NAME}_node
   ${PROJECT_NAME}_tasks
   tesseract::tesseract_common
+  tesseract::tesseract_collision_vhacd_convex_decomposition
   tesseract::tesseract_command_language
   tesseract::tesseract_task_composer
   tesseract::tesseract_task_composer_planning_nodes

--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -10,6 +10,7 @@
   <!-- Scan Link -->
   <arg name="collision_object_type" default="convex_mesh" description="Collision model representation for scan mesh (convex_mesh, mesh, octree)"/>
   <arg name="octree_resolution" default="0.010"/>
+  <arg name="max_convex_hulls" default="64"/>
   <!-- Task Composer -->
   <arg name="task_composer_config_file" default="$(find-pkg-share snp_motion_planning)/config/task_composer_plugins.yaml"/>
   <arg name="raster_task_name" default="SNPPipeline"/>
@@ -39,6 +40,7 @@
     <!-- Scan Link -->
     <param name="collision_object_type" value="$(var collision_object_type)"/>
     <param name="octree_resolution" value="$(var octree_resolution)"/>
+    <param name="max_convex_hulls" value="$(var max_convex_hulls)"/>
     <!-- Task Composer -->
     <param name="task_composer_config_file" value="$(var task_composer_config_file)"/>
     <param name="raster_task_name" value="$(var raster_task_name)"/>


### PR DESCRIPTION
This PR adds the ability to add the scan mesh to the motion planning environment as a set of convex hulls using convex decomposition provided by VHACD in `tesseract`