### PR TITLE
Planner Profile Update

### DIFF
--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -49,7 +49,8 @@ typename tesseract_planning::DescartesLadderGraphSolverProfile<FloatType>::Ptr c
 template <typename FloatType>
 typename tesseract_planning::DescartesDefaultPlanProfile<FloatType>::Ptr
 createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatType>(0.0),
-                           const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {})
+                           const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {},
+                           const FloatType longest_valid_segment_length = static_cast<FloatType>(0.05))
 {
   auto profile = std::make_shared<tesseract_planning::DescartesDefaultPlanProfile<FloatType>>();
   profile->use_redundant_joint_solutions = false;
@@ -67,6 +68,7 @@ createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatTyp
   profile->vertex_collision_check_config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
   profile->vertex_collision_check_config.contact_manager_config.margin_data.setDefaultCollisionMargin(
       min_contact_distance);
+  profile->vertex_collision_check_config.longest_valid_segment_length = longest_valid_segment_length;
 
   profile->vertex_collision_check_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::MODIFY;
@@ -78,6 +80,7 @@ createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatTyp
   profile->edge_collision_check_config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
   profile->edge_collision_check_config.contact_manager_config.margin_data.setDefaultCollisionMargin(
       min_contact_distance);
+  profile->edge_collision_check_config.longest_valid_segment_length = longest_valid_segment_length;
 
   profile->edge_collision_check_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::MODIFY;
@@ -89,7 +92,9 @@ createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatTyp
 }
 
 tesseract_planning::OMPLRealVectorPlanProfile::Ptr createOMPLProfile(
-    const double min_contact_distance = 0.0, const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {})
+    const double min_contact_distance = 0.0,
+    const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {},
+    const double longest_valid_segment_length = 0.05)
 {
   // OMPL freespace and transition profiles
   // Create the RRT parameters
@@ -115,6 +120,7 @@ tesseract_planning::OMPLRealVectorPlanProfile::Ptr createOMPLProfile(
   profile->collision_check_config.contact_manager_config.margin_data.setDefaultCollisionMargin(min_contact_distance);
   profile->collision_check_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::MODIFY;
+  profile->collision_check_config.longest_valid_segment_length = longest_valid_segment_length;
 
   for (const ExplicitCollisionPair& pair : unique_collision_pairs)
     profile->collision_check_config.contact_manager_config.margin_data.setPairCollisionMargin(pair.first, pair.second,
@@ -151,7 +157,8 @@ createTrajOptToolZFreePlanProfile(const Eigen::VectorXd& cart_tolerance = Eigen:
 }
 
 std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOptProfile(
-    double min_contact_distance = 0.0, const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {})
+    double min_contact_distance = 0.0, const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {},
+    double longest_valid_segment_length = 0.05)
 {
   // TrajOpt profiles
   auto profile = std::make_shared<tesseract_planning::TrajOptDefaultCompositeProfile>();
@@ -182,6 +189,7 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
   {
     profile->collision_cost_config.coeff = 10.0;
     profile->collision_cost_config.type = tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE;
+    profile->longest_valid_segment_length = longest_valid_segment_length;
 
     // Use a relatively large safety margin to drive the robot away from collision
     profile->collision_cost_config.safety_margin = std::max(0.025, min_contact_distance);

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -48,9 +48,9 @@ typename tesseract_planning::DescartesLadderGraphSolverProfile<FloatType>::Ptr c
 
 template <typename FloatType>
 typename tesseract_planning::DescartesDefaultPlanProfile<FloatType>::Ptr
-createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatType>(0.0),
-                           const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {},
-                           const FloatType longest_valid_segment_length = static_cast<FloatType>(0.05))
+createDescartesPlanProfile(FloatType min_contact_distance,
+                           const std::vector<ExplicitCollisionPair>& unique_collision_pairs,
+                           const FloatType longest_valid_segment_length)
 {
   auto profile = std::make_shared<tesseract_planning::DescartesDefaultPlanProfile<FloatType>>();
   profile->use_redundant_joint_solutions = false;
@@ -91,10 +91,9 @@ createDescartesPlanProfile(FloatType min_contact_distance = static_cast<FloatTyp
   return profile;
 }
 
-tesseract_planning::OMPLRealVectorPlanProfile::Ptr createOMPLProfile(
-    const double min_contact_distance = 0.0,
-    const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {},
-    const double longest_valid_segment_length = 0.05)
+tesseract_planning::OMPLRealVectorPlanProfile::Ptr
+createOMPLProfile(const double min_contact_distance, const std::vector<ExplicitCollisionPair>& unique_collision_pairs,
+                  const double longest_valid_segment_length)
 {
   // OMPL freespace and transition profiles
   // Create the RRT parameters
@@ -156,9 +155,9 @@ createTrajOptToolZFreePlanProfile(const Eigen::VectorXd& cart_tolerance = Eigen:
   return profile;
 }
 
-std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOptProfile(
-    double min_contact_distance = 0.0, const std::vector<ExplicitCollisionPair>& unique_collision_pairs = {},
-    double longest_valid_segment_length = 0.05)
+std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile>
+createTrajOptProfile(double min_contact_distance, const std::vector<ExplicitCollisionPair>& unique_collision_pairs,
+                     double longest_valid_segment_length)
 {
   // TrajOpt profiles
   auto profile = std::make_shared<tesseract_planning::TrajOptDefaultCompositeProfile>();
@@ -179,8 +178,9 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
    * computed to prevent optimization instability, but the computed collision cost will be zero
    *
    * Therefore, we should set the safety margin relatively high such that non-zero collision costs are computed and
-   * drive the robot away from collision. We can make the safety margin buffer a fixed size (usually 2cm is appropriate) as the
-   * safety margin to ensure that the optimization does not move in the direction of collision even when the cost is zero.
+   * drive the robot away from collision. We can make the safety margin buffer a fixed size (usually 2cm is appropriate)
+   * as the safety margin to ensure that the optimization does not move in the direction of collision even when the cost
+   * is zero.
    */
 
   // Collision cost
@@ -193,13 +193,14 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
 
     // Use a relatively large safety margin to drive the robot away from collision
     profile->collision_cost_config.safety_margin = std::max(0.025, min_contact_distance);
-    // Use a small, fixed-size buffer beyond the defined margin to continue calculating collision avoidance gradients even when the collision avoidance cost is zero
+    // Use a small, fixed-size buffer beyond the defined margin to continue calculating collision avoidance gradients
+    // even when the collision avoidance cost is zero
     profile->collision_cost_config.safety_margin_buffer = 0.025;
 
     if (!unique_collision_pairs.empty())
     {
-      profile->special_collision_cost =
-          std::make_shared<trajopt_common::SafetyMarginData>(profile->collision_cost_config.safety_margin, profile->collision_cost_config.coeff);
+      profile->special_collision_cost = std::make_shared<trajopt_common::SafetyMarginData>(
+          profile->collision_cost_config.safety_margin, profile->collision_cost_config.coeff);
 
       // Populate the special collision cost
       for (const ExplicitCollisionPair& pair : unique_collision_pairs)
@@ -215,15 +216,17 @@ std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile> createTrajOp
     profile->collision_constraint_config.coeff = 10.0;
     profile->collision_constraint_config.type = tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE;
 
-    // Use a minimal safety margin, such that the constraint is only violated (and therefore a cost produced) when the robot is actually considered to be in collision
+    // Use a minimal safety margin, such that the constraint is only violated (and therefore a cost produced) when the
+    // robot is actually considered to be in collision
     profile->collision_constraint_config.safety_margin = min_contact_distance;
-    // Use a small, fixed-size buffer beyond the defined margin to continue calculating collision avoidance gradients even when the collision avoidance cost is zero
+    // Use a small, fixed-size buffer beyond the defined margin to continue calculating collision avoidance gradients
+    // even when the collision avoidance cost is zero
     profile->collision_constraint_config.safety_margin_buffer = 0.025;
 
-    if(!unique_collision_pairs.empty())
+    if (!unique_collision_pairs.empty())
     {
-      profile->special_collision_constraint =
-          std::make_shared<trajopt_common::SafetyMarginData>(min_contact_distance, profile->collision_constraint_config.coeff);
+      profile->special_collision_constraint = std::make_shared<trajopt_common::SafetyMarginData>(
+          min_contact_distance, profile->collision_constraint_config.coeff);
 
       // Populate the special collision constraint
       for (const ExplicitCollisionPair& pair : unique_collision_pairs)
@@ -241,8 +244,8 @@ std::shared_ptr<tesseract_planning::SimplePlannerLVSPlanProfile> createSimplePla
 }
 
 tesseract_planning::ContactCheckProfile::Ptr
-createContactCheckProfile(double longest_valid_segment_distance, double min_contact_distance = 0.0,
-                          const std::vector<ExplicitCollisionPair>& collision_pairs = {})
+createContactCheckProfile(double longest_valid_segment_distance, double min_contact_distance,
+                          const std::vector<ExplicitCollisionPair>& collision_pairs)
 {
   auto profile =
       std::make_shared<tesseract_planning::ContactCheckProfile>(longest_valid_segment_distance, min_contact_distance);

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -463,7 +463,8 @@ private:
       {
         auto scan_contact_links = get<std::vector<std::string>>(node_, SCAN_REDUCED_CONTACT_LINKS_PARAM);
         for (const std::string& link : scan_contact_links)
-          collision_pairs.emplace_back(link, SCAN_LINK_NAME, 0.0);
+          if (!link.empty())
+            collision_pairs.emplace_back(link, SCAN_LINK_NAME, 0.0);
       }
 
       // Simple planner

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -505,7 +505,8 @@ private:
                                    velocity_scaling_factor, acceleration_scaling_factor));
 
       // Discrete contact check profile
-      profile_dict->addProfile(CONTACT_CHECK_DEFAULT_NAMESPACE, PROFILE,
+      profile_dict->addProfile(
+          CONTACT_CHECK_DEFAULT_NAMESPACE, PROFILE,
           createContactCheckProfile(longest_valid_segment_length, min_contact_dist, collision_pairs));
 
       // Constant TCP time parameterization profile


### PR DESCRIPTION
This PR makes several changes to the planner profiles to correct some issues encountered with motion planning across multiple regions:

- Use the LVS parameter for all motion planning tasks, rather than relying on their default values
- Correctly set the `trajopt` collision margin and collision margin buffer for the collision avoidance cost. This was previously set to the `min_contact_distance`, which defaults to zero, meaning collision avoidance was not happening until the optimization moved a state into collision.
- Only add the `trajopt` special collision cost/constraint when there are explicit collision pairs to override. Previously, an erroneous explicit collision pair would be generated with a blank string, causing the collision margin in `trajopt` to change under the hood
- Correctly set the `trajopt` collision margin for the special collision cost/constraint. This should match the collision margin for the associated cost/constraint
- Enable the `trajopt` collision constraint with `min_contact_distance` as the collision margin. This doesn't seem to impact convergence times significantly (when tested with `snp_automate_2023` and `blending_m5_sfsa`) but it helps to ensure trajectories planned by `trajopt` are collision-free. Additionally, the weight of the collision avoidance constraint can be increased if the constraint continues to be violated, whereas this cannot happen when just the collision avoidance cost is enabled.

## Before
During transitions between regions, the end effector geometry appears to drag the surface rather than being pushed up away from it.

https://github.com/user-attachments/assets/6ff46710-fccd-4047-a65b-3205a8eb6fcd

## After

During transitions between regions, the end effector geometry gets pushed up away from the surface of the part.

https://github.com/user-attachments/assets/1b5abfc9-be0e-4864-883b-ae8a6c1f5407