### PR TITLE
Fix go home freespace planning

### DIFF
--- a/snp_application/config/snp.xml
+++ b/snp_application/config/snp.xml
@@ -5,19 +5,10 @@
       <ReactiveSequence>
         <RosSpinner/>
         <ButtonMonitor name="Reset"
-                       button="reset"
+                       button="halt"
                        _description="Sequence has been reset to start state"/>
-        <KeepRunningUntilFailure>
-          <ForceSuccess>
-            <ReactiveSequence>
-              <ButtonMonitor name="Halt"
-                             button="halt"
-                             _description="Current task has been halted"/>
-              <SubTree ID="go_home_process"
-                       _autoremap="true"/>
-            </ReactiveSequence>
-          </ForceSuccess>
-        </KeepRunningUntilFailure>
+        <SubTree ID="go_home_process"
+                 _autoremap="true"/>
       </ReactiveSequence>
     </ForceSuccess>
   </BehaviorTree>

--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -188,7 +188,7 @@ task_composer_plugins:
               config:
                 conditional: false
                 inputs:
-                  planning_input: planning_input
+                  planning_input: input_data
                 outputs:
                   program: input_data
             FormatInputTask:

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -554,7 +554,7 @@ private:
     }
 
     auto task_data = std::make_shared<tesseract_planning::TaskComposerDataStorage>();
-    task_data->setData("planning_input", program);
+    task_data->setData("input_data", program);
     task_data->setData("environment", std::shared_ptr<const tesseract_environment::Environment>(env_));
     task_data->setData("profiles", profile_dict);
 

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -584,15 +584,24 @@ private:
     result->wait();
     log.context = result->context;
 
-    // Save the output dot graph
-    std::stringstream dotgraph_ss;
-    static_cast<const tesseract_planning::TaskComposerGraph&>(*task).dump(dotgraph_ss, nullptr,
-                                                                          result->context->task_infos.getInfoMap());
-    log.dotgraph = dotgraph_ss.str();
+    // Save the full log, including the output dot graph
+    {
+      std::stringstream dotgraph_ss;
+      static_cast<const tesseract_planning::TaskComposerGraph&>(*task).dump(dotgraph_ss, nullptr,
+                                                                            result->context->task_infos.getInfoMap());
 
-    // Save task composer log
-    const std::string log_filepath = tesseract_common::getTempPath() + task_name + "_log";
-    tesseract_common::Serialization::toArchiveFileBinary<tesseract_planning::TaskComposerLog>(log, log_filepath);
+      // Save the dot graph to a separate file for convenience
+      {
+        std::ofstream output_graph(tesseract_common::getTempPath() + task_name + "_results.dot");
+        output_graph << dotgraph_ss.str();
+      }
+
+      log.dotgraph = dotgraph_ss.str();
+
+      // Save task composer log
+      const std::string log_filepath = tesseract_common::getTempPath() + task_name + "_log";
+      tesseract_common::Serialization::toArchiveFileBinary<tesseract_planning::TaskComposerLog>(log, log_filepath);
+    }
 
     // Reset the log level
     console_bridge::setLogLevel(log_level);


### PR DESCRIPTION
Changes per commit message to fix freespace planning for go-home operations. This PR also updates the nominal behavior tree which was repeatedly running the motion planning on failure