### PR TITLE
Add service for adding scan link to motion planning environment

### DIFF
--- a/snp_application/config/snp.btproj
+++ b/snp_application/config/snp.btproj
@@ -3,6 +3,9 @@
     <include path="snp.xml"/>
     <!-- Description of Node Models (used by Groot) -->
     <TreeNodesModel>
+        <Action ID="AddScanLinkService" editable="true">
+            <input_port name="service_name" default="add_scan_link"/>
+        </Action>
         <Action ID="ButtonApproval" editable="true">
             <input_port name="approve_button"/>
             <input_port name="disapprove_button"/>
@@ -14,6 +17,9 @@
             <input_port name="first"/>
             <input_port name="second"/>
             <output_port name="output"/>
+        </Action>
+        <Action ID="EmptyService" editable="true">
+            <input_port name="service_name"/>
         </Action>
         <Action ID="ExecuteMotionPlanService" editable="true">
             <input_port name="service_name" default="execute_motion_plan"/>

--- a/snp_application/config/snp.xml
+++ b/snp_application/config/snp.xml
@@ -206,6 +206,8 @@
 
   <BehaviorTree ID="scan">
     <Sequence>
+      <EmptyService name="Remove Scan Link"
+                    service_name="remove_scan_link"/>
       <TriggerService name="Enable Robot"
                       service_name="robot_enable"/>
       <GetCurrentJointState topic_name="/joint_states"
@@ -224,6 +226,8 @@
                                    trajectory="{process}"/>
       <StopReconstructionService name="Stop Reconstruction"
                                  service_name="stop_reconstruction"/>
+      <AddScanLinkService name="Add Scan Link"
+                          service_name="add_scan_link"/>
       <FollowJointTrajectoryAction name="Execute Scan Departure Motion"
                                    action_name="{follow_joint_trajectory_action}"
                                    trajectory="{departure}"/>
@@ -234,6 +238,11 @@
 
   <!-- Description of Node Models (used by Groot) -->
   <TreeNodesModel>
+    <Action ID="AddScanLinkService"
+            editable="true">
+      <input_port name="service_name"
+                  default="add_scan_link"/>
+    </Action>
     <Action ID="ButtonApproval"
             editable="true">
       <input_port name="approve_button"/>
@@ -248,6 +257,10 @@
       <input_port name="first"/>
       <input_port name="second"/>
       <output_port name="output"/>
+    </Action>
+    <Action ID="EmptyService"
+            editable="true">
+      <input_port name="service_name"/>
     </Action>
     <Action ID="FollowJointTrajectoryAction"
             editable="true">

--- a/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
@@ -16,7 +16,9 @@
 #include <snp_msgs/srv/generate_freespace_motion_plan.hpp>
 #include <snp_msgs/srv/generate_scan_motion_plan.hpp>
 #include <snp_msgs/srv/generate_tool_paths.hpp>
+#include <snp_msgs/srv/add_scan_link.hpp>
 #include <std_srvs/srv/trigger.hpp>
+#include <std_srvs/srv/empty.hpp>
 
 namespace snp_application
 {
@@ -106,6 +108,16 @@ public:
   BT::NodeStatus onResponseReceived(const typename Response::SharedPtr& response) override;
 };
 
+class EmptyServiceNode : public SnpRosServiceNode<std_srvs::srv::Empty>
+{
+public:
+  using SnpRosServiceNode<std_srvs::srv::Empty>::providedPorts;
+  using SnpRosServiceNode<std_srvs::srv::Empty>::SnpRosServiceNode;
+
+  bool setRequest(typename Request::SharedPtr& request) override;
+  BT::NodeStatus onResponseReceived(const typename Response::SharedPtr& response) override;
+};
+
 class ExecuteMotionPlanServiceNode : public SnpRosServiceNode<snp_msgs::srv::ExecuteMotionPlan>
 {
 public:
@@ -139,6 +151,16 @@ public:
   }
 
   using SnpRosServiceNode<snp_msgs::srv::GenerateMotionPlan>::SnpRosServiceNode;
+
+  bool setRequest(typename Request::SharedPtr& request) override;
+  BT::NodeStatus onResponseReceived(const typename Response::SharedPtr& response) override;
+};
+
+class AddScanLinkServiceNode : public SnpRosServiceNode<snp_msgs::srv::AddScanLink>
+{
+public:
+  using SnpRosServiceNode<snp_msgs::srv::AddScanLink>::providedPorts;
+  using SnpRosServiceNode<snp_msgs::srv::AddScanLink>::SnpRosServiceNode;
 
   bool setRequest(typename Request::SharedPtr& request) override;
   BT::NodeStatus onResponseReceived(const typename Response::SharedPtr& response) override;

--- a/snp_application/src/bt/plugins.cpp
+++ b/snp_application/src/bt/plugins.cpp
@@ -32,6 +32,7 @@ BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory,
 
   factory.registerNodeType<snp_application::RosSpinnerNode>("RosSpinner", params.nh);
   factory.registerNodeType<snp_application::TriggerServiceNode>("TriggerService", params);
+  factory.registerNodeType<snp_application::EmptyServiceNode>("EmptyService", params);
   factory.registerNodeType<snp_application::ExecuteMotionPlanServiceNode>("ExecuteMotionPlanService", params);
   factory.registerNodeType<snp_application::ToolPathsPubNode>("ToolPathsPub", params);
   factory.registerNodeType<snp_application::MotionPlanPubNode>("MotionPlanPub", params);
@@ -49,6 +50,7 @@ BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory,
   try_declare_parameter<std::string>(params.nh, MOTION_GROUP_PARAM, "");
   try_declare_parameter<std::string>(params.nh, REF_FRAME_PARAM, "");
   try_declare_parameter<std::string>(params.nh, TCP_FRAME_PARAM, "");
+  factory.registerNodeType<snp_application::AddScanLinkServiceNode>("AddScanLinkService", params);
   factory.registerNodeType<snp_application::GenerateMotionPlanServiceNode>("GenerateMotionPlanService", params);
 
   try_declare_parameter<std::string>(params.nh, FREESPACE_MOTION_GROUP_PARAM, "");

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -19,6 +19,16 @@ BT::NodeStatus TriggerServiceNode::onResponseReceived(const typename Response::S
   return BT::NodeStatus::SUCCESS;
 }
 
+bool EmptyServiceNode::setRequest(typename Request::SharedPtr& /*request*/)
+{
+  return true;
+}
+
+BT::NodeStatus EmptyServiceNode::onResponseReceived(const typename Response::SharedPtr& /*response*/)
+{
+  return BT::NodeStatus::SUCCESS;
+}
+
 bool ExecuteMotionPlanServiceNode::setRequest(typename Request::SharedPtr& request)
 {
   request->motion_plan = getBTInput<trajectory_msgs::msg::JointTrajectory>(this, MOTION_PLAN_INPUT_PORT_KEY);
@@ -42,8 +52,6 @@ bool GenerateMotionPlanServiceNode::setRequest(typename Request::SharedPtr& requ
 
   request->motion_group = get_parameter<std::string>(node_, MOTION_GROUP_PARAM);
   request->tcp_frame = get_parameter<std::string>(node_, TCP_FRAME_PARAM);
-  request->mesh_filename = get_parameter<std::string>(node_, MESH_FILE_PARAM);
-  request->mesh_frame = get_parameter<std::string>(node_, REF_FRAME_PARAM);
 
   return true;
 }
@@ -64,6 +72,24 @@ BT::NodeStatus GenerateMotionPlanServiceNode::onResponseReceived(const typename 
   return BT::NodeStatus::SUCCESS;
 }
 
+bool AddScanLinkServiceNode::setRequest(typename Request::SharedPtr& request)
+{
+  request->mesh_filename = get_parameter<std::string>(node_, MESH_FILE_PARAM);
+  request->mesh_frame = get_parameter<std::string>(node_, REF_FRAME_PARAM);
+  return true;
+}
+
+BT::NodeStatus AddScanLinkServiceNode::onResponseReceived(const typename Response::SharedPtr& response)
+{
+  if (!response->success)
+  {
+    config().blackboard->set(ERROR_MESSAGE_KEY, response->message);
+    return BT::NodeStatus::FAILURE;
+  }
+
+  return BT::NodeStatus::SUCCESS;
+}
+
 sensor_msgs::msg::JointState jointTrajectoryPointToJointState(const trajectory_msgs::msg::JointTrajectory& jt,
                                                               const trajectory_msgs::msg::JointTrajectoryPoint& jtp)
 {
@@ -79,8 +105,6 @@ bool GenerateFreespaceMotionPlanServiceNode::setRequest(typename Request::Shared
   request->js2 = snp_application::getBTInput<sensor_msgs::msg::JointState>(this, GOAL_JOINT_STATE_INPUT_PORT_KEY);
 
   request->motion_group = get_parameter<std::string>(node_, FREESPACE_MOTION_GROUP_PARAM);
-  request->mesh_filename = get_parameter<std::string>(node_, MESH_FILE_PARAM);
-  request->mesh_frame = get_parameter<std::string>(node_, REF_FRAME_PARAM);
   request->tcp_frame = get_parameter<std::string>(node_, TCP_FRAME_PARAM);
 
   return true;

--- a/snp_msgs/CMakeLists.txt
+++ b/snp_msgs/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(sensor_msgs REQUIRED)
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
   "msg/ToolPath.msg"
+  "srv/AddScanLink.srv"
   "srv/ExecuteMotionPlan.srv"
   "srv/GenerateMotionPlan.srv"
   "srv/GenerateToolPaths.srv"

--- a/snp_msgs/srv/AddScanLink.srv
+++ b/snp_msgs/srv/AddScanLink.srv
@@ -1,0 +1,11 @@
+# Request
+
+string mesh_filename
+string mesh_frame
+
+---
+# Response
+
+# Success and error information
+bool success
+string message

--- a/snp_msgs/srv/GenerateFreespaceMotionPlan.srv
+++ b/snp_msgs/srv/GenerateFreespaceMotionPlan.srv
@@ -6,11 +6,6 @@ string tcp_frame
 sensor_msgs/JointState js1
 sensor_msgs/JointState js2
 
-# Mesh - this is the scanned mesh which toolpaths were generated on.  Any path generated should be
-# checked for collision against this mesh to ensure we don't hit it by mistake.
-string mesh_filename # Optional - If left empty then no mesh will be added
-string mesh_frame
-
 ---
 # Response
 

--- a/snp_msgs/srv/GenerateMotionPlan.srv
+++ b/snp_msgs/srv/GenerateMotionPlan.srv
@@ -10,11 +10,6 @@ snp_msgs/ToolPath[] tool_paths
 string motion_group
 string tcp_frame
 
-# Mesh - this is the scanned mesh which toolpaths were generated on.  Any path generated should be
-# checked for collision against this mesh to ensure we don't hit it by mistake.
-string mesh_filename # Optional - If left empty then no mesh will be added
-string mesh_frame
-
 ---
 # Response
 


### PR DESCRIPTION
This PR adds a service for explicitly adding the scan link mesh to the collision environment. This PR also updates the behavior tree to remove the previous scan link at the beginning of the scan process and add the link to the collision environment at the end of the scan process