### PR TITLE
Motion Planning Debug Improvements

### DIFF
--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -16,7 +16,7 @@ MinLengthTask: &min_length
   config:
     conditional: true
     inputs:
-      program: input_data
+      program: input_program
       environment: environment
       profiles: profiles
     outputs:
@@ -28,7 +28,7 @@ KinematicLimitsCheckTask: &limits_check
   config:
     conditional: true
     inputs:
-      program: output_data
+      program: output_program
       environment: environment
       profiles: profiles
 
@@ -49,9 +49,9 @@ task_composer_plugins:
         class: GraphTaskFactory
         config:
           inputs:
-            program: input_data
+            program: input_program
           outputs:
-            program: output_data
+            program: output_program
           nodes:
             DoneTask: *done
             ErrorTask: *error
@@ -84,7 +84,7 @@ task_composer_plugins:
                   environment: environment
                   profiles: profiles
                 outputs:
-                  program: output_data
+                  program: output_program
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
@@ -102,9 +102,9 @@ task_composer_plugins:
         class: GraphTaskFactory
         config:
           inputs:
-            program: input_data
+            program: input_program
           outputs:
-            program: output_data
+            program: output_program
           nodes:
             DoneTask: *done
             ErrorTask: *error
@@ -138,7 +138,7 @@ task_composer_plugins:
                 inputs:
                   keys: [trajopt_output]
                 outputs:
-                  keys: [output_data]
+                  keys: [output_program]
             OMPLMotionPlannerTask:
               class: OMPLMotionPlannerTaskFactory
               config:
@@ -166,7 +166,7 @@ task_composer_plugins:
                 inputs:
                   programs: [ompl_output]
                 outputs:
-                  programs: [output_data]
+                  programs: [output_program]
             TrajOptOMPLMotionPlannerTask:
               class: TrajOptMotionPlannerTaskFactory
               config:
@@ -196,17 +196,17 @@ task_composer_plugins:
                 inputs:
                   keys: [trajopt_ompl_output]
                 outputs:
-                  keys: [output_data]
+                  keys: [output_program]
             IterativeSplineParameterizationTask:
               class: IterativeSplineParameterizationTaskFactory
               config:
                 conditional: true
                 inputs:
-                  program: output_data
+                  program: output_program
                   environment: environment
                   profiles: profiles
                 outputs:
-                  program: output_data
+                  program: output_program
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
@@ -238,9 +238,9 @@ task_composer_plugins:
         class: GraphTaskFactory
         config:
           inputs:
-            program: input_data
+            program: input_program
           outputs:
-            program: output_data
+            program: output_program
           nodes:
             DoneTask: *done
             ErrorTask: *error
@@ -249,16 +249,16 @@ task_composer_plugins:
               config:
                 conditional: false
                 inputs:
-                  program: input_data
+                  program: input_program
                   environment: environment
                 outputs:
-                  program: input_data
+                  program: input_program
             SimpleMotionPlannerTask:
               class: SimpleMotionPlannerTaskFactory
               config:
                 conditional: true
                 inputs:
-                  program: input_data
+                  program: input_program
                   environment: environment
                   profiles: profiles
                 outputs:
@@ -288,30 +288,30 @@ task_composer_plugins:
                   task: SNPFreespacePipeline
                   config:
                     indexing:
-                      - input_data
+                      - input_program
                       - min_length_output
                       - trajopt_output
                       - ompl_output
                       - trajopt_ompl_output
-                      - output_data
+                      - output_program
                 raster:
                   task: SNPCartesianPipeline
                   config:
                     indexing:
-                      - input_data
+                      - input_program
                       - min_length_output
                       - trajopt_output
-                      - output_data
+                      - output_program
                 transition:
                   task: SNPFreespacePipeline
                   config:
                     indexing:
-                      - input_data
+                      - input_program
                       - min_length_output
                       - trajopt_output
                       - ompl_output
                       - trajopt_ompl_output
-                      - output_data
+                      - output_program
             TCPSpeedLimiterTask:
               class: TCPSpeedLimiterTaskFactory
               config:
@@ -321,7 +321,7 @@ task_composer_plugins:
                   environment: environment
                   profiles: profiles
                 outputs:
-                  program: output_data
+                  program: output_program
           edges:
             - source: FormatInputTask
               destinations: [SimpleMotionPlannerTask]

--- a/snp_motion_planning/config/task_composer_plugins.yaml
+++ b/snp_motion_planning/config/task_composer_plugins.yaml
@@ -1,63 +1,36 @@
 # Anchors
 
-raw: &raw_inputs
-  program: input_data
-  environment: environment
-  profiles: profiles
-mod: &mod_inputs
-  program: output_data
-  environment: environment
-  profiles: profiles
-
 DoneTask: &done
   class: DoneTaskFactory
   config:
     conditional: false
+
 ErrorTask: &error
   class: ErrorTaskFactory
   config:
     conditional: false
     trigger_abort: true
+
 MinLengthTask: &min_length
   class: MinLengthTaskFactory
   config:
     conditional: true
-    inputs: *raw_inputs
+    inputs:
+      program: input_data
+      environment: environment
+      profiles: profiles
     outputs:
-      program: output_data
+      program: min_length_output
     format_result_as_input: false
-TrajOptMotionPlannerTask: &trajopt
-  class: TrajOptMotionPlannerTaskFactory
-  config:
-    conditional: true
-    inputs: *mod_inputs
-    outputs:
-      program: output_data
-    format_result_as_input: false
-DiscreteContactCheckTask: &contact_check
-  class: DiscreteContactCheckTaskFactory
-  config:
-    conditional: true
-    inputs: *mod_inputs
-ConstantTCPSpeedTimeParameterizationTask: &constant_tcp_speed
-  class: ConstantTCPSpeedTimeParameterizationTaskFactory
-  config:
-    conditional: true
-    inputs: *mod_inputs
-    outputs:
-      program: output_data
-IterativeSplineParameterizationTask: &isp
-  class: IterativeSplineParameterizationTaskFactory
-  config:
-    conditional: true
-    inputs: *mod_inputs
-    outputs:
-      program: output_data
+
 KinematicLimitsCheckTask: &limits_check
   class: KinematicLimitsCheckTaskFactory
   config:
     conditional: true
-    inputs: *mod_inputs
+    inputs:
+      program: output_data
+      environment: environment
+      profiles: profiles
 
 # Task composer configuration
 task_composer_plugins:
@@ -83,9 +56,35 @@ task_composer_plugins:
             DoneTask: *done
             ErrorTask: *error
             MinLengthTask: *min_length
-            TrajOptMotionPlannerTask: *trajopt
-            DiscreteContactCheckTask: *contact_check
-            ConstantTCPSpeedTimeParameterizationTask: *constant_tcp_speed
+            TrajOptMotionPlannerTask:
+              class: TrajOptMotionPlannerTaskFactory
+              config:
+                conditional: true
+                inputs:
+                  program: min_length_output
+                  environment: environment
+                  profiles: profiles
+                outputs:
+                  program: trajopt_output
+                format_result_as_input: false
+            DiscreteContactCheckTask:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                conditional: true
+                inputs:
+                  program: trajopt_output
+                  environment: environment
+                  profiles: profiles
+            ConstantTCPSpeedTimeParameterizationTask:
+              class: ConstantTCPSpeedTimeParameterizationTaskFactory
+              config:
+                conditional: true
+                inputs:
+                  program: trajopt_output
+                  environment: environment
+                  profiles: profiles
+                outputs:
+                  program: output_data
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
@@ -110,63 +109,125 @@ task_composer_plugins:
             DoneTask: *done
             ErrorTask: *error
             MinLengthTask: *min_length
-            OMPLMotionPlannerTask:
-              class: OMPLMotionPlannerTaskFactory
+            TrajOptMotionPlannerTask:
+              class: TrajOptMotionPlannerTaskFactory
               config:
+                namespace: TrajOptMotionPlannerTask
                 conditional: true
-                inputs: *mod_inputs
+                inputs:
+                  program: min_length_output
+                  environment: environment
+                  profiles: profiles
                 outputs:
-                  program: output_data
-                format_result_as_input: true
-            TrajOptMotionPlannerTask: *trajopt
-            DiscreteContactCheckTask: *contact_check
-            IterativeSplineParameterizationTask: *isp
-            KinematicLimitsCheckTask: *limits_check
-          edges:
-            - source: MinLengthTask
-              destinations: [ErrorTask, OMPLMotionPlannerTask]
-            - source: OMPLMotionPlannerTask
-              destinations: [ErrorTask, TrajOptMotionPlannerTask]
-            - source: TrajOptMotionPlannerTask
-              destinations: [ErrorTask, DiscreteContactCheckTask]
-            - source: DiscreteContactCheckTask
-              destinations: [ErrorTask, IterativeSplineParameterizationTask]
-            - source: IterativeSplineParameterizationTask
-              destinations: [ErrorTask, KinematicLimitsCheckTask]
-            - source: KinematicLimitsCheckTask
-              destinations: [ErrorTask, DoneTask]
-          terminals: [ErrorTask, DoneTask]
-      SNPTransitionPipeline:
-        class: GraphTaskFactory
-        config:
-          inputs:
-            program: input_data
-          outputs:
-            program: output_data
-          nodes:
-            DoneTask: *done
-            ErrorTask: *error
-            MinLengthTask: *min_length
-            TrajOptMotionPlannerTask: *trajopt
-            OMPLMotionPlannerTask:
-              class: OMPLMotionPlannerTaskFactory
-              config:
-                conditional: true
-                inputs: *mod_inputs
-                outputs:
-                  program: output_data
+                  program: trajopt_output
                 format_result_as_input: false
-            DiscreteContactCheckTask: *contact_check
-            IterativeSplineParameterizationTask: *isp
+            DiscreteContactCheckTrajOptTask:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                namespace: DiscreteContactCheckTask
+                conditional: true
+                inputs:
+                  program: trajopt_output
+                  environment: environment
+                  profiles: profiles
+            RemapTrajOptTask:
+              class: RemapTaskFactory
+              config:
+                conditional: true
+                copy: true
+                inputs:
+                  keys: [trajopt_output]
+                outputs:
+                  keys: [output_data]
+            OMPLMotionPlannerTask:
+              class: OMPLMotionPlannerTaskFactory
+              config:
+                conditional: true
+                inputs:
+                  program: trajopt_output
+                  environment: environment
+                  profiles: profiles
+                outputs:
+                  program: ompl_output
+                format_result_as_input: true
+            DiscreteContactCheckOMPLTask:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                namespace: DiscreteContactCheckTask
+                conditional: true
+                inputs:
+                  program: ompl_output
+                  environment: environment
+                  profiles: profiles
+            RemapOMPLTask:
+              class: FormatAsResultTaskFactory
+              config:
+                conditional: true
+                inputs:
+                  programs: [ompl_output]
+                outputs:
+                  programs: [output_data]
+            TrajOptOMPLMotionPlannerTask:
+              class: TrajOptMotionPlannerTaskFactory
+              config:
+                namespace: TrajOptMotionPlannerTask
+                conditional: true
+                inputs:
+                  program: ompl_output
+                  environment: environment
+                  profiles: profiles
+                outputs:
+                  program: trajopt_ompl_output
+                format_result_as_input: false
+            DiscreteContactCheckTrajOptOMPLTask:
+              class: DiscreteContactCheckTaskFactory
+              config:
+                namespace: DiscreteContactCheckTask
+                conditional: true
+                inputs:
+                  program: trajopt_ompl_output
+                  environment: environment
+                  profiles: profiles
+            RemapTrajOptOMPLTask:
+              class: RemapTaskFactory
+              config:
+                conditional: true
+                copy: true
+                inputs:
+                  keys: [trajopt_ompl_output]
+                outputs:
+                  keys: [output_data]
+            IterativeSplineParameterizationTask:
+              class: IterativeSplineParameterizationTaskFactory
+              config:
+                conditional: true
+                inputs:
+                  program: output_data
+                  environment: environment
+                  profiles: profiles
+                outputs:
+                  program: output_data
             KinematicLimitsCheckTask: *limits_check
           edges:
             - source: MinLengthTask
               destinations: [ErrorTask, TrajOptMotionPlannerTask]
             - source: TrajOptMotionPlannerTask
-              destinations: [OMPLMotionPlannerTask, DiscreteContactCheckTask]
+              destinations: [OMPLMotionPlannerTask, DiscreteContactCheckTrajOptTask]
+            - source: DiscreteContactCheckTrajOptTask
+              destinations: [OMPLMotionPlannerTask, RemapTrajOptTask]
+            - source: RemapTrajOptTask
+              destinations: [ErrorTask, IterativeSplineParameterizationTask]
             - source: OMPLMotionPlannerTask
-              destinations: [ErrorTask, DiscreteContactCheckTask]
-            - source: DiscreteContactCheckTask
+              destinations: [ErrorTask, TrajOptOMPLMotionPlannerTask]
+            - source: TrajOptOMPLMotionPlannerTask
+              destinations: [DiscreteContactCheckOMPLTask, DiscreteContactCheckTrajOptOMPLTask]
+            - source: DiscreteContactCheckOMPLTask
+              destinations: [ErrorTask, RemapOMPLTask]
+            - source: RemapOMPLTask
+              destinations: [ErrorTask, IterativeSplineParameterizationTask]
+            - source: DiscreteContactCheckTrajOptOMPLTask
+              destinations: [ErrorTask, RemapTrajOptOMPLTask]
+            - source: RemapTrajOptOMPLTask
               destinations: [ErrorTask, IterativeSplineParameterizationTask]
             - source: IterativeSplineParameterizationTask
               destinations: [ErrorTask, KinematicLimitsCheckTask]
@@ -183,14 +244,6 @@ task_composer_plugins:
           nodes:
             DoneTask: *done
             ErrorTask: *error
-            ProcessInputTask:
-              class: ProcessPlanningInputTaskFactory
-              config:
-                conditional: false
-                inputs:
-                  planning_input: input_data
-                outputs:
-                  program: input_data
             FormatInputTask:
               class: FormatPlanningInputTaskFactory
               config:
@@ -204,58 +257,72 @@ task_composer_plugins:
               class: SimpleMotionPlannerTaskFactory
               config:
                 conditional: true
-                inputs: *raw_inputs
+                inputs:
+                  program: input_data
+                  environment: environment
+                  profiles: profiles
                 outputs:
-                  program: output_data
+                  program: simple_output
                 format_result_as_input: true
             DescartesMotionPlannerTask:
               class: DescartesFMotionPlannerTaskFactory
               config:
                 conditional: true
-                inputs: *mod_inputs
+                inputs:
+                  program: simple_output
+                  environment: environment
+                  profiles: profiles
                 outputs:
-                  program: output_data
+                  program: descartes_output
                 format_result_as_input: true
             RasterMotionTask:
               class: RasterMotionTaskFactory
               config:
                 conditional: true
                 inputs:
-                  program: output_data
+                  program: descartes_output
                   environment: environment
                 outputs:
-                  program: output_data
+                  program: raster_output
                 freespace:
                   task: SNPFreespacePipeline
                   config:
-                    remapping:
-                      input_data: output_data
-                      output_data: output_data
-                    indexing: [output_data]
+                    indexing:
+                      - input_data
+                      - min_length_output
+                      - trajopt_output
+                      - ompl_output
+                      - trajopt_ompl_output
+                      - output_data
                 raster:
                   task: SNPCartesianPipeline
                   config:
-                    remapping:
-                      input_data: output_data
-                      output_data: output_data
-                    indexing: [output_data]
+                    indexing:
+                      - input_data
+                      - min_length_output
+                      - trajopt_output
+                      - output_data
                 transition:
-                  task: SNPTransitionPipeline
+                  task: SNPFreespacePipeline
                   config:
-                    remapping:
-                      input_data: output_data
-                      output_data: output_data
-                    indexing: [output_data]
+                    indexing:
+                      - input_data
+                      - min_length_output
+                      - trajopt_output
+                      - ompl_output
+                      - trajopt_ompl_output
+                      - output_data
             TCPSpeedLimiterTask:
               class: TCPSpeedLimiterTaskFactory
               config:
                 conditional: true
-                inputs: *mod_inputs
+                inputs:
+                  program: raster_output
+                  environment: environment
+                  profiles: profiles
                 outputs:
                   program: output_data
           edges:
-            - source: ProcessInputTask
-              destinations: [FormatInputTask]
             - source: FormatInputTask
               destinations: [SimpleMotionPlannerTask]
             - source: SimpleMotionPlannerTask

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -571,7 +571,7 @@ private:
     }
 
     auto task_data = std::make_shared<tesseract_planning::TaskComposerDataStorage>();
-    task_data->setData("input_data", program);
+    task_data->setData("input_program", program);
     task_data->setData("environment", std::shared_ptr<const tesseract_environment::Environment>(env_));
     task_data->setData("profiles", profile_dict);
 

--- a/snp_motion_planning/src/plugins/tasks/constant_tcp_speed_time_parameterization_task.cpp
+++ b/snp_motion_planning/src/plugins/tasks/constant_tcp_speed_time_parameterization_task.cpp
@@ -65,6 +65,7 @@ public:
       const tesseract_planning::TaskComposerPluginFactory& /*plugin_factory*/)
     : tesseract_planning::TaskComposerTask(std::move(name), ports(), config)
   {
+    validatePorts();
   }
 
   ~ConstantTCPSpeedTimeParameterizationTask() override = default;

--- a/snp_motion_planning/src/plugins/tasks/kinematic_limits_check_task.cpp
+++ b/snp_motion_planning/src/plugins/tasks/kinematic_limits_check_task.cpp
@@ -20,7 +20,7 @@
 #include <tesseract_task_composer/core/task_composer_task_plugin_factory.h>
 
 // Requried
-const std::string INOUT_PROGRAM_PORT = "program";
+const std::string INPUT_PROGRAM_PORT = "program";
 const std::string INPUT_ENVIRONMENT_PORT = "environment";
 const std::string INPUT_PROFILES_PORT = "profiles";
 
@@ -40,14 +40,12 @@ public:
   }
 
   explicit KinematicLimitsCheckTask(std::string name, std::string input_program_key, std::string input_environment_key,
-                                    std::string input_profiles_key, std::string output_program_key,
-                                    bool is_conditional = true)
+                                    std::string input_profiles_key, bool is_conditional = true)
     : tesseract_planning::TaskComposerTask(std::move(name), KinematicLimitsCheckTask::ports(), is_conditional)
   {
-    input_keys_.add(INOUT_PROGRAM_PORT, std::move(input_program_key));
+    input_keys_.add(INPUT_PROGRAM_PORT, std::move(input_program_key));
     input_keys_.add(INPUT_ENVIRONMENT_PORT, std::move(input_environment_key));
     input_keys_.add(INPUT_PROFILES_PORT, std::move(input_profiles_key));
-    output_keys_.add(INOUT_PROGRAM_PORT, std::move(output_program_key));
     validatePorts();
   }
 
@@ -55,6 +53,7 @@ public:
                                     const tesseract_planning::TaskComposerPluginFactory& /*plugin_factory*/)
     : tesseract_planning::TaskComposerTask(std::move(name), KinematicLimitsCheckTask::ports(), config)
   {
+    validatePorts();
   }
 
   ~KinematicLimitsCheckTask() override = default;
@@ -113,7 +112,7 @@ protected:
 
     auto env = env_poly.as<std::shared_ptr<const tesseract_environment::Environment>>();
 
-    auto input_data_poly = getData(*context.data_storage, INOUT_PROGRAM_PORT);
+    auto input_data_poly = getData(*context.data_storage, INPUT_PROGRAM_PORT);
     if (input_data_poly.getType() != std::type_index(typeid(tesseract_planning::CompositeInstruction)))
     {
       info.color = "red";

--- a/snp_motion_planning/src/plugins/tasks/tcp_speed_limiter_task.cpp
+++ b/snp_motion_planning/src/plugins/tasks/tcp_speed_limiter_task.cpp
@@ -63,6 +63,7 @@ public:
                                const tesseract_planning::TaskComposerPluginFactory& /*plugin_factory*/)
     : tesseract_planning::TaskComposerTask(std::move(name), ports(), config)
   {
+    validatePorts();
   }
 
   ~TCPSpeedLimiterTask() override = default;
@@ -161,7 +162,7 @@ protected:
       return info;
     }
 
-    context.data_storage->setData(INOUT_PROGRAM_PORT, input_data_poly);
+    setData(*context.data_storage, INOUT_PROGRAM_PORT, input_data_poly);
 
     info.color = "green";
     info.status_message = "TCP speed limiter task succeeded";


### PR DESCRIPTION
This PR replaces #130 to provide a few improvements to the motion planning pipeline.

This PR updates the task composer config file not to overwrite elements in the data storage, such that the outputs of each planning step in the pipeline can be visualized using the task composer log file (added in #158).

This PR also updates the freespace motion planning pipeline to be more robust by being able to use the output trajectories of Trajopt, OMPL, or OMPL + Trajopt (depending on which tasks fail) rather than just failing outright if one of the planners does not succeed. The updated pipeline graph is shown in the image below.

![SNPFreespacePipeline](https://github.com/user-attachments/assets/7464d059-b8c4-4dab-89de-165a3b044e3b)

The Cartesian planning pipeline and raster pipelines remain functionally the same, but the input/output keys were changed so as not to overwrite data between planning steps.

![SNPCartesianPipeline](https://github.com/user-attachments/assets/6dc346f7-a506-4e5e-907f-4e59d475f369)
![SNPPipeline dot](https://github.com/user-attachments/assets/755febc2-b214-4794-973c-8e0752ee6c7e)