### PR TITLE
Setting the default recipe filepath based on parameter

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -5,7 +5,7 @@
 - git:
     local-name: noether
     uri: https://github.com/ros-industrial/noether.git
-    version: 3e6e402fb345115f525002ff679aaa6905be5c01
+    version: f1bdfa23a7dbe1c4d50154b5a25b55c233dd544d
 - git:
     local-name: industrial_reconstruction
     uri: https://github.com/ros-industrial/industrial_reconstruction.git

--- a/snp_tpp/src/tpp_widget.cpp
+++ b/snp_tpp/src/tpp_widget.cpp
@@ -74,7 +74,13 @@ TPPWidget::TPPWidget(rclcpp::Node::SharedPtr node, boost_plugin_loader::PluginLo
 
   layout->addWidget(tool_bar);
 
-  pipeline_widget_ = new noether::ConfigurableTPPPipelineWidget(std::move(loader), this);
+  // Set the default configuration file directory for the tool path planner
+  std::string default_configuration_file_directory;
+  node->declare_parameter("default_configuration_file_directory", default_configuration_file_directory);
+  node->get_parameter("default_configuration_file_directory", default_configuration_file_directory);
+
+  pipeline_widget_ =
+      new noether::ConfigurableTPPPipelineWidget(std::move(loader), default_configuration_file_directory, this);
   layout->addWidget(pipeline_widget_);
 
   // Set up the ROS interfaces


### PR DESCRIPTION
When combined with [this PR on Noether](https://github.com/ros-industrial/noether/pull/297), the default filepath for recipes can be set via a launch file parameter. Addresses PR #168.