### PR TITLE
Coefficient fix in SNPRasterPlannerWidget

### DIFF
--- a/snp_tpp/src/snp_raster_planner_widget.cpp
+++ b/snp_tpp/src/snp_raster_planner_widget.cpp
@@ -35,8 +35,7 @@ void SNPRasterPlannerWidget::save(YAML::Node& config) const
 
 noether::ToolPathPlanner::ConstPtr SNPRasterPlannerWidget::create() const
 {
-  auto dir_gen = std::make_unique<noether::PrincipalAxisDirectionGenerator>(
-      M_PI * ui_->double_spin_box_rotation_offset->value() / 180.0);
+  auto dir_gen = std::make_unique<noether::PrincipalAxisDirectionGenerator>(ui_->double_spin_box_rotation_offset->value());
   auto orig_gen = std::make_unique<noether::CentroidOriginGenerator>();
   auto planner = std::make_unique<noether::PlaneSlicerRasterPlanner>(std::move(dir_gen), std::move(orig_gen));
   planner->setLineSpacing(ui_->double_spin_box_line_spacing->value());


### PR DESCRIPTION
Unit conversion takes place in Noether now. Removing the radian conversion in the SNP raster planner.