### PR TITLE
Remove tool path waypoint rotation in motion planner

### DIFF
--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -109,9 +109,6 @@ tesseract_common::Toolpath fromMsg(const std::vector<snp_msgs::msg::ToolPath>& p
         Eigen::Isometry3d p;
         tf2::fromMsg(pose, p);
 
-        // Rotate the pose 180 degrees about the x-axis such that the z-axis faces into the part
-        p *= Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX());
-
         seg.push_back(p);
       }
       tps.push_back(seg);


### PR DESCRIPTION
This PR removes the 180 degree rotation of the tool path waypoints in the motion planner. This causes some problems because generally, it is assumed that the motion planning process aligns the TCP frame directly with the input Cartesian waypoints. 

Removing this arbitrary rotation allows this general assumption to be true (which is helpful for end-users) and allows the visualization to be more consistent (i.e., what you see is in Rviz is how it appears to the motion planner).

Note: downstream URDFs that currently work with SNP will need to rotate their current TCP frames to accommodate for this change.

Addresses #173 