### PR TITLE
Fix BT text edit logger segfaults

### DIFF
--- a/snp_application/src/bt/text_edit_logger.cpp
+++ b/snp_application/src/bt/text_edit_logger.cpp
@@ -81,7 +81,6 @@ void TextEditLogger::callback(BT::Duration /*timestamp*/, const BT::TreeNode& no
 
   if (!message.isEmpty())
   {
-    log_->textCursor().movePosition(QTextCursor::End);
     QMetaObject::invokeMethod(log_, "append", Qt::QueuedConnection, Q_ARG(QString, message));
   }
 }


### PR DESCRIPTION
I've occasionally experienced segfaults in the application Rviz panel that were a result of attempting to set the cursor position in the text edit before writing to the text edit:

https://github.com/ros-industrial-consortium/scan_n_plan_workshop/blob/9a662452965f955ba8be1d256f9fd291279237cf/snp_application/src/bt/text_edit_logger.cpp#L84

Since the text-edit is read-only and we are trying to call `QTextEdit::append`, this call is unnecessary and can be removed to prevent the occasional segfaults.

