### PR TITLE
Add Camera TCP parameter to `SnpBlackboard`

### DIFF
--- a/snp_application/include/snp_application/snp_behavior_tree.h
+++ b/snp_application/include/snp_application/snp_behavior_tree.h
@@ -24,6 +24,7 @@ inline const char* HOME_STATE_JOINT_POSITIONS_PARAM = "home_state_joint_position
 inline const char* REF_FRAME_PARAM = "reference_frame";
 inline const char* TCP_FRAME_PARAM = "tcp_frame";
 inline const char* CAMERA_FRAME_PARAM = "camera_frame";
+inline const char* CAMERA_TCP_FRAME_PARAM = "camera_tcp_frame";
 // Scan
 inline const char* SCAN_MOTION_GROUP_PARAM = "scan_motion_group";
 inline const char* SCAN_TRAJ_FILE_PARAM = "scan_trajectory_file";

--- a/snp_application/src/snp_behavior_tree.cpp
+++ b/snp_application/src/snp_behavior_tree.cpp
@@ -77,6 +77,7 @@ SnpBlackboard::SnpBlackboard(rclcpp::Node::SharedPtr node, BT::Blackboard::Ptr p
   node->declare_parameter<std::string>(REF_FRAME_PARAM);
   node->declare_parameter<std::string>(TCP_FRAME_PARAM);
   node->declare_parameter<std::string>(CAMERA_FRAME_PARAM);
+  node->declare_parameter<std::string>(CAMERA_TCP_FRAME_PARAM);
   // Scan
   node->declare_parameter<std::string>(SCAN_MOTION_GROUP_PARAM);
   node->declare_parameter<std::string>(SCAN_TRAJ_FILE_PARAM);


### PR DESCRIPTION
For higher accuracy, we would like to specify calibrated camera frames relative to controller-reported flange frames (which generally intrinsically capture the robot's factory kinematic calibration) rather than attach it to a frame in the URDF based on the nominal kinematics of the robot. However, this causes some minor challenges with motion planning because the current implementation of Tesseract requires all named frames used for planning to exist in the URDF (i.e., not be TF frames published by some external node).

To support this, we need to separate the specification of `camera_frame` (the calibrated camera frame, which might be attached to a controller-repored TF frame outside of the URDF) from `camera_tcp_frame` (a frame defined in the URDF that represents the camera frame for planning purposes).

This PR adds a ROS parameter (and consequently a blackboard entry through the `SnpBlackboard` class) for the `camera_tcp_frame` which can be used for planning tasks