### PR TITLE
Update `StartReconstructionService` BT node

### DIFF
--- a/snp_application/config/snp.btproj
+++ b/snp_application/config/snp.btproj
@@ -94,14 +94,16 @@
             <input_port name="ref_frame" default="{reference_frame}"/>
             <input_port name="voxel_length" default="{ir_voxel_length}"/>
             <input_port name="sdf_trunc" default="{ir_sdf_trunc}"/>
+            <input_port name="depth_scale" default="{ir_depth_scale}"/>
+            <input_port name="depth_trunc" default="{ir_depth_trunc}"/>
+            <input_port name="translation_filter_distance" default="{ir_translation_filter_distance}"/>
+            <input_port name="rotation_filter_distance" default="{ir_rotation_filter_distance}"/>
             <input_port name="min_x" default="{ir_min_x}"/>
             <input_port name="min_y" default="{ir_min_y}"/>
             <input_port name="min_z" default="{ir_min_z}"/>
             <input_port name="max_x" default="{ir_max_x}"/>
             <input_port name="max_y" default="{ir_max_y}"/>
             <input_port name="max_z" default="{ir_max_z}"/>
-            <input_port name="depth_scale" default="{ir_depth_scale}"/>
-            <input_port name="depth_trunc" default="{ir_depth_trunc}"/>
             <input_port name="live_reconstruction" default="{ir_live}"/>
         </Action>
         <Action ID="StopReconstructionService" editable="true">

--- a/snp_application/config/snp.xml
+++ b/snp_application/config/snp.xml
@@ -237,14 +237,16 @@
                                   ref_frame="{reference_frame}"
                                   voxel_length="{ir_voxel_length}"
                                   sdf_trunc="{ir_sdf_trunc}"
+                                  depth_scale="{ir_depth_scale}"
+                                  depth_trunc="{ir_depth_trunc}"
+                                  translation_filter_distance="{ir_translation_filter_distance}"
+                                  rotation_filter_distance="{ir_rotation_filter_distance}"
                                   min_x="{ir_min_x}"
                                   min_y="{ir_min_y}"
                                   min_z="{ir_min_z}"
                                   max_x="{ir_max_x}"
                                   max_y="{ir_max_y}"
                                   max_z="{ir_max_z}"
-                                  depth_scale="{ir_depth_scale}"
-                                  depth_trunc="{ir_depth_trunc}"
                                   live_reconstruction="{ir_live}"/>
       <FollowJointTrajectoryAction name="Execute Scan Motion"
                                    action_name="{follow_joint_trajectory_action}"
@@ -421,6 +423,14 @@
                   default="{ir_voxel_length}"/>
       <input_port name="sdf_trunc"
                   default="{ir_sdf_trunc}"/>
+      <input_port name="depth_scale"
+                  default="{ir_depth_scale}"/>
+      <input_port name="depth_trunc"
+                  default="{ir_depth_trunc}"/>
+      <input_port name="translation_filter_distance"
+                  default="{ir_translation_filter_distance}"/>
+      <input_port name="rotation_filter_distance"
+                  default="{ir_rotation_filter_distance}"/>
       <input_port name="min_x"
                   default="{ir_min_x}"/>
       <input_port name="min_y"
@@ -433,10 +443,6 @@
                   default="{ir_max_y}"/>
       <input_port name="max_z"
                   default="{ir_max_z}"/>
-      <input_port name="depth_scale"
-                  default="{ir_depth_scale}"/>
-      <input_port name="depth_trunc"
-                  default="{ir_depth_trunc}"/>
       <input_port name="live_reconstruction"
                   default="{ir_live}"/>
     </Action>

--- a/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
+++ b/snp_application/include/snp_application/bt/snp_bt_ros_nodes.h
@@ -274,24 +274,27 @@ public:
   inline static const std::string REF_FRAME_INPUT_PORT_KEY = "ref_frame";
   inline static const std::string VOXEL_LENGTH_INPUT_PORT_KEY = "voxel_length";
   inline static const std::string SDF_TRUNC_INPUT_PORT_KEY = "sdf_trunc";
+  inline static const std::string DEPTH_SCALE_INPUT_PORT_KEY = "depth_scale";
+  inline static const std::string DEPTH_TRUNC_INPUT_PORT_KEY = "depth_trunc";
+  inline static const std::string TRANSLATION_FILTER_DISTANCE_KEY = "translation_filter_distance";
+  inline static const std::string ROTATION_FILTER_DISTANCE_KEY = "rotation_filter_distance";
   inline static const std::string MIN_X_INPUT_PORT_KEY = "min_x";
   inline static const std::string MIN_Y_INPUT_PORT_KEY = "min_y";
   inline static const std::string MIN_Z_INPUT_PORT_KEY = "min_z";
   inline static const std::string MAX_X_INPUT_PORT_KEY = "max_x";
   inline static const std::string MAX_Y_INPUT_PORT_KEY = "max_y";
   inline static const std::string MAX_Z_INPUT_PORT_KEY = "max_z";
-  inline static const std::string DEPTH_SCALE_INPUT_PORT_KEY = "depth_scale";
-  inline static const std::string DEPTH_TRUNC_INPUT_PORT_KEY = "depth_trunc";
   inline static const std::string LIVE_RECONSTRUCTION_INPUT_PORT_KEY = "live_reconstruction";
   inline static BT::PortsList providedPorts()
   {
     return providedBasicPorts(
         { BT::InputPort<std::string>(CAMERA_FRAME_INPUT_PORT_KEY), BT::InputPort<std::string>(REF_FRAME_INPUT_PORT_KEY),
           BT::InputPort<double>(VOXEL_LENGTH_INPUT_PORT_KEY), BT::InputPort<double>(SDF_TRUNC_INPUT_PORT_KEY),
+          BT::InputPort<double>(DEPTH_SCALE_INPUT_PORT_KEY), BT::InputPort<double>(DEPTH_TRUNC_INPUT_PORT_KEY),
+          BT::InputPort<double>(TRANSLATION_FILTER_DISTANCE_KEY), BT::InputPort<double>(ROTATION_FILTER_DISTANCE_KEY),
           BT::InputPort<double>(MIN_X_INPUT_PORT_KEY), BT::InputPort<double>(MIN_Y_INPUT_PORT_KEY),
           BT::InputPort<double>(MIN_Z_INPUT_PORT_KEY), BT::InputPort<double>(MAX_X_INPUT_PORT_KEY),
           BT::InputPort<double>(MAX_Y_INPUT_PORT_KEY), BT::InputPort<double>(MAX_Z_INPUT_PORT_KEY),
-          BT::InputPort<double>(DEPTH_SCALE_INPUT_PORT_KEY), BT::InputPort<double>(DEPTH_TRUNC_INPUT_PORT_KEY),
           BT::InputPort<bool>(LIVE_RECONSTRUCTION_INPUT_PORT_KEY) });
   }
 

--- a/snp_application/include/snp_application/snp_behavior_tree.h
+++ b/snp_application/include/snp_application/snp_behavior_tree.h
@@ -143,6 +143,28 @@ inline const char* IR_TSDF_VOXEL_PARAM = "ir_voxel_length";
  */
 inline const char* IR_TSDF_SDF_PARAM = "ir_sdf_trunc";
 /**
+ * @brief Parameter defining the depth scale factor used to convert depth image pixel values to meters
+ * @ingroup bt_params
+ */
+inline const char* IR_RGBD_DEPTH_SCALE_PARAM = "ir_depth_scale";
+/**
+ * @brief Parameter defining the depth truncation distance (m) of points in depth images
+ * @ingroup bt_params
+ */
+inline const char* IR_RGBD_DEPTH_TRUNC_PARAM = "ir_depth_trunc";
+/**
+ * @brief Parameter defining the minimum translational distance (m) that the camera frame must travel before a new image
+ * is integrated into the TSDF volume
+ * @ingroup bt_params
+ */
+inline const char* IR_TRANSLATION_FILTER_DISTANCE = "ir_translation_filter_distance";
+/**
+ * @brief Parameter defining the minimum rotational distance (rad) that the camera frame must travel before a new image
+ * is integrated into the TSDF volume
+ * @ingroup bt_params
+ */
+inline const char* IR_ROTATION_FILTER_DISTANCE = "ir_rotation_filter_distance";
+/**
  * @brief Parameter defining the x-value of the minimum point of the TSDF volume
  * @ingroup bt_params
  */
@@ -170,16 +192,6 @@ inline const char* IR_TSDF_MAX_Y_PARAM = "ir_max_y";
  * @ingroup bt_params
  */
 inline const char* IR_TSDF_MAX_Z_PARAM = "ir_max_z";
-/**
- * @brief Parameter defining the depth scale factor used to convert depth image pixel values to meters
- * @ingroup bt_params
- */
-inline const char* IR_RGBD_DEPTH_SCALE_PARAM = "ir_depth_scale";
-/**
- * @brief Parameter defining the depth truncation distance (m) of points in depth images
- *  @ingroup bt_params
- */
-inline const char* IR_RGBD_DEPTH_TRUNC_PARAM = "ir_depth_trunc";
 /**
  * @brief Parameter defining a flag for running the reconstruction process with "live" feedback
  * @ingroup bt_params

--- a/snp_application/src/bt/snp_bt_ros_nodes.cpp
+++ b/snp_application/src/bt/snp_bt_ros_nodes.cpp
@@ -159,6 +159,8 @@ bool StartReconstructionServiceNode::setRequest(typename Request::SharedPtr& req
 {
   request->tracking_frame = getBTInput<std::string>(this, CAMERA_FRAME_INPUT_PORT_KEY);
   request->relative_frame = getBTInput<std::string>(this, REF_FRAME_INPUT_PORT_KEY);
+  request->translation_distance = getBTInput<double>(this, TRANSLATION_FILTER_DISTANCE_KEY);
+  request->rotational_distance = getBTInput<double>(this, ROTATION_FILTER_DISTANCE_KEY);
   request->tsdf_params.voxel_length = getBTInput<double>(this, VOXEL_LENGTH_INPUT_PORT_KEY);
   request->tsdf_params.sdf_trunc = getBTInput<double>(this, SDF_TRUNC_INPUT_PORT_KEY);
   request->tsdf_params.min_box_values.x = getBTInput<double>(this, MIN_X_INPUT_PORT_KEY);

--- a/snp_application/src/snp_behavior_tree.cpp
+++ b/snp_application/src/snp_behavior_tree.cpp
@@ -90,14 +90,16 @@ SnpBlackboard::SnpBlackboard(rclcpp::Node::SharedPtr node, BT::Blackboard::Ptr p
   // Industrial Reconstruction
   node->declare_parameter<double>(IR_TSDF_VOXEL_PARAM);
   node->declare_parameter<double>(IR_TSDF_SDF_PARAM);
+  node->declare_parameter<double>(IR_RGBD_DEPTH_SCALE_PARAM);
+  node->declare_parameter<double>(IR_RGBD_DEPTH_TRUNC_PARAM);
+  node->declare_parameter<double>(IR_TRANSLATION_FILTER_DISTANCE);
+  node->declare_parameter<double>(IR_ROTATION_FILTER_DISTANCE);
   node->declare_parameter<double>(IR_TSDF_MIN_X_PARAM);
   node->declare_parameter<double>(IR_TSDF_MIN_Y_PARAM);
   node->declare_parameter<double>(IR_TSDF_MIN_Z_PARAM);
   node->declare_parameter<double>(IR_TSDF_MAX_X_PARAM);
   node->declare_parameter<double>(IR_TSDF_MAX_Y_PARAM);
   node->declare_parameter<double>(IR_TSDF_MAX_Z_PARAM);
-  node->declare_parameter<double>(IR_RGBD_DEPTH_SCALE_PARAM);
-  node->declare_parameter<double>(IR_RGBD_DEPTH_TRUNC_PARAM);
   node->declare_parameter<bool>(IR_LIVE_PARAM);
   node->declare_parameter<double>(IR_NORMAL_ANGLE_TOL_PARAM);
   node->declare_parameter<double>(IR_NORMAL_X_PARAM);


### PR DESCRIPTION
We previously had not been setting the translation/rotation filter distance parameters in the `StartReconstruction` service, which leads to potentially undefined behavior in the `industrial_reconstruction` node, where these parameters are extracted from the service request.

This PR adds input ports to the `StartReconstructionService` node for the translation/rotation filter distances and adds a ROS parameter for them