### PR TITLE
Added checks to handle partially empty toolpaths 

### DIFF
--- a/snp_application/include/snp_application/bt/utils.h
+++ b/snp_application/include/snp_application/bt/utils.h
@@ -8,6 +8,8 @@ namespace snp_application
 /** @brief BT blackboard key for recording error messages from BT nodes */
 inline static const std::string ERROR_MESSAGE_KEY = "error_message";
 
+inline static const std::string WARN_MESSAGE_KEY = "warn_message";
+
 template <typename T>
 T getBTInput(const BT::TreeNode* node, const std::string& port)
 {

--- a/snp_application/src/bt/text_edit_logger.cpp
+++ b/snp_application/src/bt/text_edit_logger.cpp
@@ -19,6 +19,7 @@ void TextEditLogger::callback(BT::Duration /*timestamp*/, const BT::TreeNode& no
 
   static const QString info_html = "<font color=\"Grey\">";
   static const QString success_html = "<font color=\"Green\">";
+  static const QString warn_html = "<font color=\"Orange\">";
   static const QString end_html = "</font>";
   static const QString tab_html = "&nbsp;&nbsp;";
 
@@ -34,10 +35,19 @@ void TextEditLogger::callback(BT::Duration /*timestamp*/, const BT::TreeNode& no
           ss << info_html << "[ " << QString::fromStdString(node.name()) << " ]" << tab_html << "->" << tab_html
              << "RUNNING" << end_html;
           break;
-        case BT::NodeStatus::SUCCESS:
+        case BT::NodeStatus::SUCCESS: {
           ss << success_html << "[ " << QString::fromStdString(node.name()) << " ]" << tab_html << "->" << tab_html
              << "SUCCESS" << end_html;
+
+          QString warn_msg = QString::fromStdString(node.config().blackboard->get<std::string>(WARN_MESSAGE_KEY));
+          if (!warn_msg.isEmpty())
+          {
+            ss << "<br>" << warn_html << warn_msg << end_html;
+            node.config().blackboard->set(WARN_MESSAGE_KEY, "");
+          }
+
           break;
+        }
         case BT::NodeStatus::FAILURE: {
           ss << fail_html << "[ " << QString::fromStdString(node.name()) << " ]";
 

--- a/snp_application/src/snp_behavior_tree.cpp
+++ b/snp_application/src/snp_behavior_tree.cpp
@@ -11,6 +11,7 @@ SnpBlackboard::SnpBlackboard(rclcpp::Node::SharedPtr node, BT::Blackboard::Ptr p
 {
   // Set the error message key in the blackboard
   set(ERROR_MESSAGE_KEY, "");
+  set(WARN_MESSAGE_KEY, "");
 
   // Lambda for setting blackboard values from ROS2 parameters
   auto update_from_parameters =


### PR DESCRIPTION
This PR addresses a bug in the `PlanToolPathServiceNode` Class in `snp_bt_ros_nodes.cpp` where if toolpaths are present in the service request (`!response->tool_paths.empty()`) but the toolpaths within `tool_paths` are empty (`response->tool_paths.tool_paths.empty() == true`) the behavior tree node will succeed, it will publish an empty toolpath, and it will not provide meaningful feedback to the user.   

The following has been added as part of this PR to address this:
* Added additional checks for partially empty toolpaths
* Exposed warning messages for `BT::NodeStatus::SUCCESS` in the `text_edit_logger`

When a toolpath is partially empty (ex: when two regions are circled with the `Polygon Selection Tool` and the `ROISelection` mesh modifier is applied, and one region contains a toolpath and the other region contains an empty toolpath) the behavior tree node will return `BT::NodeStatus::SUCCESS`, generate the nonempty toolpath, and warn the user in the `text_edit_logger` that there are other toolpaths that may be empty. This allows the user to more easily see which toolpaths succeeded in generating and which did not. 

See below for an example from the `text_edit_logger`:
<img width="474" height="255" alt="Screenshot from 2025-11-25 14-56-37" src="https://github.com/user-attachments/assets/35f8ff57-5c82-481f-826b-7faddd23cc75" />

Warning messages can also be added to accompany `BT::NodeStatus::SUCCESS` messages to give the developer the ability to generate warnings for BT Nodes that have succeeded but may contain unexpected output that is not severe enough to return a `BT::NodeStatus::FAILURE`.


