### PR TITLE
Update QSettings Check in TPP Dialog Window

### DIFF
--- a/snp_application/src/snp_widget.cpp
+++ b/snp_application/src/snp_widget.cpp
@@ -72,25 +72,16 @@ public:
         break;
     }
 
+    // Get the last saved TPP configuration file from the QSettings
     QSettings settings;
-    settings.sync();
+    const QString last_file = settings.value(noether::ConfigurableTPPPipelineWidget::SETTINGS_KEY_LAST_FILE).toString();
 
-    switch (settings.status())
-    {
-      case QSettings::Status::AccessError:
-        QMessageBox::warning(this, "Access Error",
-                             "Failed to access the Qt settings for this application; please ensure the directory "
-                             "'$HOME/.config' is read/write accessible.");
-        break;
-      case QSettings::Status::FormatError:
-        QMessageBox::warning(this, "Format Error", "Invalid format for the Qt settings for this application.");
-        break;
-      case QSettings::Status::NoError:
-      default: {
-        QString last_file = settings.value(noether::ConfigurableTPPPipelineWidget::SETTINGS_KEY_LAST_FILE).toString();
-        node_->set_parameter(rclcpp::Parameter(PROCESS_TPP_CONFIG_FILE_PARAM, last_file.toStdString()));
-      }
-    }
+    if (last_file.isNull() || last_file.isEmpty())
+      QMessageBox::warning(this, "QSettings Error",
+                           "Failed to extract last saved TPP configuration file from QSettings."
+                           "Please ensure the directory '$HOME/.config' is read/write accessible.");
+    else
+      node_->set_parameter(rclcpp::Parameter(PROCESS_TPP_CONFIG_FILE_PARAM, last_file.toStdString()));
 
     event->accept();
   }


### PR DESCRIPTION
#197 added a check to the status of the `QSettings` object in the TPP dialog window in the SNP widget. After a little more extensive testing, it appears that this check returns an `AccessError` on Ubuntu 22.04 (Qt version 5.15) regardless of whether the `QSettings` configuration file exists in the `~/.config` directory or not. Interestingly, `QSettings` does seem to be able to create, write, and read from this file even though the status shows `AccessError`.

[This StackOverflow post](https://forum.qt.io/topic/84614/qsettings-problem-when-input-file-is-a-link/16) mentioned a similar issue (specifically when dealing with symlinks for the configuration files), with the solution being updating the permissions for the `/etc/config/` and `~/.config` directories to allow read/write access by the user and their group. I confirmed that the permissions of those directories on my local Ubuntu 22.04 had the correct permissions, but `QSettings::status` still returns access error in every location that `QSettings` is used (i.e., in `noether` and in SNP).

As a workaround, this PR changes the check to verify that the value extracted from the `QSettings` object is not null or empty under the assumption that it would be null or empty if the `QSettings` file could not be accessed (which was the initial issue addressed by #197)

