### PR TITLE
Publishing TSDF volume marker in reconstruction sim node

### DIFF
--- a/snp_scanning/scripts/reconstruction_sim_node
+++ b/snp_scanning/scripts/reconstruction_sim_node
@@ -2,6 +2,7 @@
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, HistoryPolicy, ReliabilityPolicy, DurabilityPolicy
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import sys
 import open3d
 from industrial_reconstruction_msgs.srv import StartReconstruction
@@ -43,12 +44,12 @@ class ReconstructionSimServer(Node):
 
         self.declare_parameter(MESH_FILE_PARAMETER, rclpy.Parameter.Type.STRING)
         self.declare_parameter(REFERENCE_FRAME_PARAMETER, rclpy.Parameter.Type.STRING)
-        self.declare_parameter(TSDF_MIN_X_PARAMETER, rclpy.Parameter.Type.DOUBLE)
-        self.declare_parameter(TSDF_MIN_Y_PARAMETER, rclpy.Parameter.Type.DOUBLE)
-        self.declare_parameter(TSDF_MIN_Z_PARAMETER, rclpy.Parameter.Type.DOUBLE)
-        self.declare_parameter(TSDF_MAX_X_PARAMETER, rclpy.Parameter.Type.DOUBLE)
-        self.declare_parameter(TSDF_MAX_Y_PARAMETER, rclpy.Parameter.Type.DOUBLE)
-        self.declare_parameter(TSDF_MAX_Z_PARAMETER, rclpy.Parameter.Type.DOUBLE)
+        self.declare_parameter(TSDF_MIN_X_PARAMETER, np.nan, ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
+        self.declare_parameter(TSDF_MIN_Y_PARAMETER, np.nan, ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
+        self.declare_parameter(TSDF_MIN_Z_PARAMETER, np.nan, ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
+        self.declare_parameter(TSDF_MAX_X_PARAMETER, np.nan, ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
+        self.declare_parameter(TSDF_MAX_Y_PARAMETER, np.nan, ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
+        self.declare_parameter(TSDF_MAX_Z_PARAMETER, np.nan, ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
 
         self.get_logger().info("Started simulated reconstruction node")
 


### PR DESCRIPTION
This PR updates the reconstruction sim node to publish the TSDF volume as a `visualization_msgs::Marker` by extracting industrial reconstruction parameters. The allows the TSDF volume to be visualized when `sim_vision:=true`.

Notes: 
1. By default, the `/tsdf_volume` topic is not checked in the Rviz configuration file, so it needs to be manually checked by the user prior to executing the scan motion in Rviz to be visualized.

2. The launch files for Scan-N-Plan applications will need to be updated to pass in the necessary industrial reconstruction parameters for this change to take effect.  