### PR TITLE
Bump `noether` version to 0.15.2

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -5,7 +5,7 @@
 - git:
     local-name: noether
     uri: https://github.com/ros-industrial/noether.git
-    version: 0.15.1
+    version: 0.15.2
 - git:
     local-name: noether_ros2
     uri: https://github.com/ros-industrial/noether_ros2.git


### PR DESCRIPTION
Bumps the version of `noether` to 0.15.2 to get the update that adds header information to meshes returned by the primitive fitting mesh modifiers. This information is needed for the `ROISelectionMeshModifier` provided in this repository (which performs a TF lookup with the frame ID in the header) can work with the meshes generated by the primitive fitting mesh modifiers