### PR TITLE
Added UpsampleTrajectory profile to motion planning node

### DIFF
--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -11,6 +11,7 @@
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
 #include <tesseract_motion_planners/simple/profile/simple_planner_lvs_plan_profile.h>
 #include <tesseract_task_composer/planning/profiles/contact_check_profile.h>
+#include <tesseract_task_composer/planning/profiles/upsample_trajectory_profile.h>
 
 static const std::string TRAJOPT_DEFAULT_NAMESPACE = "TrajOptMotionPlannerTask";
 static const std::string OMPL_DEFAULT_NAMESPACE = "OMPLMotionPlannerTask";
@@ -19,6 +20,7 @@ static const std::string SIMPLE_DEFAULT_NAMESPACE = "SimpleMotionPlannerTask";
 static const std::string MIN_LENGTH_DEFAULT_NAMESPACE = "MinLengthTask";
 static const std::string CONTACT_CHECK_DEFAULT_NAMESPACE = "DiscreteContactCheckTask";
 static const std::string ISP_DEFAULT_NAMESPACE = "IterativeSplineParameterizationTask";
+static const std::string UPSAMPLE_TRAJECTORY_DEFAULT_NAMESPACE = "UpsampleTrajectoryTask";
 
 /**
  * @brief Container for a collision pair with a specifiable minimum allowable contact distance between the link pair
@@ -256,4 +258,10 @@ createContactCheckProfile(double longest_valid_segment_distance, double min_cont
     profile->config.contact_manager_config.margin_data.setPairCollisionMargin(pair.first, pair.second, pair.distance);
 
   return profile;
+}
+
+tesseract_planning::UpsampleTrajectoryProfile::Ptr
+createUpsampleTrajectoryProfile(double longest_valid_segment_distance)
+{
+  return std::make_shared<tesseract_planning::UpsampleTrajectoryProfile>(longest_valid_segment_distance);
 }

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -519,6 +519,9 @@ private:
           CONTACT_CHECK_DEFAULT_NAMESPACE, PROFILE,
           createContactCheckProfile(longest_valid_segment_length, min_contact_dist, collision_pairs));
 
+      profile_dict->addProfile(UPSAMPLE_TRAJECTORY_DEFAULT_NAMESPACE, PROFILE,
+                               createUpsampleTrajectoryProfile(longest_valid_segment_length));
+
       // Constant TCP time parameterization profile
       auto vel_trans = get<double>(node_, MAX_TRANS_VEL_PARAM);
       auto vel_rot = get<double>(node_, MAX_ROT_VEL_PARAM);


### PR DESCRIPTION
This PR adds a planning profile for the `UpsampleTrajectory` task, populated by the contact check longest valid segment distance