### PR TITLE
Make it possible to do freespace planning from the current joint pose

### DIFF
--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -773,7 +773,18 @@ private:
 
       tesseract_planning::CompositeInstruction freespace_program(PROFILE, manip_info);
 
-      tesseract_planning::JointWaypoint wp1 = rosJointStateToJointWaypoint(req->js1);
+      tesseract_planning::JointWaypoint wp1;
+      if (req->js1.name.size() > 0)
+      {
+        // If we got a starting joint states message
+        wp1 = rosJointStateToJointWaypoint(req->js1);
+      }
+      else
+      {
+        // Otherwise plan from the current state
+        const std::vector<std::string> joint_names = env_->getJointGroup(manip_info.manipulator)->getJointNames();
+        wp1 = tesseract_planning::JointWaypoint{ joint_names, env_->getCurrentJointValues(joint_names) };
+      }
       tesseract_planning::JointWaypoint wp2 = rosJointStateToJointWaypoint(req->js2);
 
       // Define a freespace move to the first waypoint

--- a/snp_msgs/srv/GenerateFreespaceMotionPlan.srv
+++ b/snp_msgs/srv/GenerateFreespaceMotionPlan.srv
@@ -3,7 +3,7 @@
 # Params
 string motion_group
 string tcp_frame
-sensor_msgs/JointState js1
+sensor_msgs/JointState js1 # If empty, plan from current state.
 sensor_msgs/JointState js2
 
 ---


### PR DESCRIPTION
Currently, the freespace planning interface requires two joint states, a start and an end state:

https://github.com/ros-industrial-consortium/scan_n_plan_workshop/blob/aae82a946f94290bf354b6c3e3f3807083fb7f32/snp_msgs/srv/GenerateFreespaceMotionPlan.srv#L1-L17

In many cases, planning should start at the current state, which is known to the planning server already.

This PR allows planning from the current state, if the incoming start joint state contains no joint names (i.e. is empty). If a start joint state **is** given then it is used. This allows us to keep using the existing interfaces in a backwards-compatible way.

## Additional notes

This is a "forward port" of our internal https://github.com/sam-xl/scan_n_plan_workshop/pull/5, as recommended by @gavanderhoorn.
